### PR TITLE
Feature/36 enter house

### DIFF
--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		52E442A528F16A6400706A74 /* InviteCodeButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E442A428F16A6400706A74 /* InviteCodeButtonView.swift */; };
 		52EBF04928E578850062EB41 /* HouseMakeNameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EBF04828E578850062EB41 /* HouseMakeNameViewController.swift */; };
 		52EBF04B28EC29200062EB41 /* TextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EBF04A28EC291F0062EB41 /* TextField.swift */; };
+		52FFDFB228FA984200DE1AE8 /* EnterHouseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52FFDFB128FA984200DE1AE8 /* EnterHouseViewController.swift */; };
 		7E1F2E2528D2123B00A5744A /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 7E1F2E2428D2123B00A5744A /* SnapKit */; };
 		7E1F2E2E28D2168300A5744A /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 7E1F2E2A28D2168200A5744A /* Pretendard-Regular.otf */; };
 		7E1F2E2F28D2168300A5744A /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 7E1F2E2B28D2168200A5744A /* Pretendard-SemiBold.otf */; };
@@ -117,6 +118,7 @@
 		52E442A428F16A6400706A74 /* InviteCodeButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteCodeButtonView.swift; sourceTree = "<group>"; };
 		52EBF04828E578850062EB41 /* HouseMakeNameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HouseMakeNameViewController.swift; sourceTree = "<group>"; };
 		52EBF04A28EC291F0062EB41 /* TextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextField.swift; sourceTree = "<group>"; };
+		52FFDFB128FA984200DE1AE8 /* EnterHouseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnterHouseViewController.swift; sourceTree = "<group>"; };
 		7E1F2E2A28D2168200A5744A /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		7E1F2E2B28D2168200A5744A /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
 		7E1F2E2C28D2168200A5744A /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
@@ -336,6 +338,7 @@
 		5227556C28B303370080DD65 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				52FFDFB028FA983100DE1AE8 /* EnterHouse */,
 				5275397A28EC75EE002D8280 /* HouseInviteCode */,
 				7EFAA86C28DA02ED00737DF0 /* CreateHouseWork */,
 				52EBF04728E578700062EB41 /* HouseMakeName */,
@@ -373,6 +376,14 @@
 				52EBF04828E578850062EB41 /* HouseMakeNameViewController.swift */,
 			);
 			path = HouseMakeName;
+			sourceTree = "<group>";
+		};
+		52FFDFB028FA983100DE1AE8 /* EnterHouse */ = {
+			isa = PBXGroup;
+			children = (
+				52FFDFB128FA984200DE1AE8 /* EnterHouseViewController.swift */,
+			);
+			path = EnterHouse;
 			sourceTree = "<group>";
 		};
 		7E1F2E2628D212E000A5744A /* Fonts */ = {
@@ -524,6 +535,7 @@
 				39EEF68528CBB80800437654 /* BaseViewController.swift in Sources */,
 				52EBF04B28EC29200062EB41 /* TextField.swift in Sources */,
 				39FABBDC28DB35020053EFD2 /* HomeCalendarView.swift in Sources */,
+				52FFDFB228FA984200DE1AE8 /* EnterHouseViewController.swift in Sources */,
 				39EEF66F28CBB5A600437654 /* NSObject+Extension.swift in Sources */,
 				39EEF68928CBB85C00437654 /* BaseTableViewCell.swift in Sources */,
 				39EEF67B28CBB65000437654 /* UserDefault+Extension.swift in Sources */,

--- a/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
+++ b/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
@@ -61,4 +61,12 @@ enum TextLiteral {
     static let houseInviteCodeViewControllerSkipButtonText: String = "건너뛰기"
     static let houseInviteCodeViewControllerCopyCodeToastLabel: String = "코드를 클립보드에 복사했습니다."
     static let houseInviteCodeViewControllerRefreshButtonText: String = "코드 재발급 받기"
+    
+    // MARK: - EnterHouseViewController
+    
+    static let enterHouseViewControllerPrimaryLabel: String = "초대코드를 입력해주세요."
+    static let enterHouseViewControllerSecondaryLabel: String = "초대코드를 입력 후 바로 공간에 참여할 수 있어요!"
+    static let enterHouseViewControllerTextfieldPlaceHolder: String = "12글자 입력"
+    static let enterHouseViewControllerToastWrongCode: String = "잘못된 코드입니다."
+    static let enterHouseViewControllerToastHouseFull: String = "하우스가 꽉 차서 참여할 수 없어요.\n6명까지만 참여할 수 있어요."
 }

--- a/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
+++ b/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let rootViewControoler = UINavigationController(rootViewController: HouseInviteCodeViewController())
+        let rootViewControoler = UINavigationController(rootViewController: EnterHouseViewController())
         window?.rootViewController = rootViewControoler
         window?.makeKeyAndVisible()
     }

--- a/fairer-iOS/fairer-iOS/Screens/EnterHouse/EnterHouseViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/EnterHouse/EnterHouseViewController.swift
@@ -33,14 +33,24 @@ final class EnterHouseViewController: BaseViewController {
         textfield.myPlaceholder = "12글자 입력"
         return textfield
     }()
-    private let enterHouseDoneButton: MainButton = {
+    private lazy var enterHouseDoneButton: MainButton = {
         let button = MainButton()
         button.isDisabled = true
         button.title = TextLiteral.doneButtonText
+        let buttonAction = UIAction { [weak self] _ in
+            self?.touchUpToShowToast()
+        }
+        button.addAction(buttonAction, for: .touchUpInside)
         return button
     }()
 
     // MARK: - lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupDelegation()
+        setupNotificationCenter()
+    }
     
     override func render() {
         view.addSubview(enterHousePrimaryLabel)
@@ -79,4 +89,85 @@ final class EnterHouseViewController: BaseViewController {
         navigationItem.largeTitleDisplayMode = .never
         navigationItem.leftBarButtonItem = backButton
     }
+    
+    private func setupDelegation() {
+        enterHouseCodeTextfield.delegate = self
+    }
+    
+    @objc private func keyboardWillShow(notification: NSNotification) {
+        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+            UIView.animate(withDuration: 0.2, animations: {
+                self.enterHouseDoneButton.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height + 20)
+            })
+        }
+    }
+    
+    @objc private func keyboardWillHide(notification:NSNotification) {
+        UIView.animate(withDuration: 0.2, animations: {
+            self.enterHouseDoneButton.transform = .identity
+        })
+    }
+    
+    private func setupNotificationCenter() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    private func touchUpToShowToast() {
+        //FIXME: - 예외 케이스에 따라 분기처리
+        showToast("잘못된 코드입니다.", 36)
+        showToast("하우스가 꽉 차서 참여할 수 없어요.\n6명까지만 참여할 수 있어요.", 56)
+    }
+    
+    private func showToast(_ message: String, _ height: Int) {
+        let toastLabel = UILabel()
+        toastLabel.text = message
+        toastLabel.textColor = .white
+        toastLabel.font = .title2
+        toastLabel.numberOfLines = 0
+        toastLabel.backgroundColor = .gray700
+        toastLabel.textAlignment = .center
+        toastLabel.layer.cornerRadius = 8
+        toastLabel.clipsToBounds = true
+        toastLabel.alpha = 0
+        view.addSubview(toastLabel)
+        toastLabel.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(2)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.height.equalTo(height)
+        }
+        UIView.animate(withDuration: 0.8, animations: {
+            toastLabel.alpha = 1.0
+        }, completion: { isCompleted in
+            UIView.animate(withDuration: 1.2, animations: {
+                toastLabel.alpha = 0
+            }, completion: { isCompleted in
+                toastLabel.removeFromSuperview()
+            })
+        })
+        
+    }
 }
+
+extension EnterHouseViewController : UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        if let char = string.cString(using: String.Encoding.utf8) {
+            let isBackSpace = strcmp(char, "\\b")
+            if isBackSpace == -92 {
+                return true
+            }
+        }
+        guard textField.text!.count < 12 else { return false }
+        return true
+    }
+    
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        let hasText = enterHouseCodeTextfield.hasText
+        enterHouseDoneButton.isDisabled = !hasText
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        view.endEditing(true)
+    }
+}
+

--- a/fairer-iOS/fairer-iOS/Screens/EnterHouse/EnterHouseViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/EnterHouse/EnterHouseViewController.swift
@@ -1,0 +1,35 @@
+//
+//  EnterHouseViewController.swift
+//  fairer-iOS
+//
+//  Created by 김유나 on 2022/10/15.
+//
+
+import UIKit
+
+import SnapKit
+
+final class EnterHouseViewController: BaseViewController {
+
+    // MARK: - property
+    
+    private let backButton = BackButton()
+
+    // MARK: - lifecycle
+    
+    override func render() {
+        
+    }
+    
+    // MARK: - functions
+    
+    override func setupNavigationBar() {
+        super.setupNavigationBar()
+        
+        let backButton = makeBarButtonItem(with: backButton)
+        
+        navigationController?.navigationBar.prefersLargeTitles = false
+        navigationItem.largeTitleDisplayMode = .never
+        navigationItem.leftBarButtonItem = backButton
+    }
+}

--- a/fairer-iOS/fairer-iOS/Screens/EnterHouse/EnterHouseViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/EnterHouse/EnterHouseViewController.swift
@@ -16,21 +16,21 @@ final class EnterHouseViewController: BaseViewController {
     private let backButton = BackButton()
     private let enterHousePrimaryLabel: UILabel = {
         let label = UILabel()
-        label.setTextWithLineHeight(text: "초대코드를 입력해주세요.", lineHeight: 28)
+        label.setTextWithLineHeight(text: TextLiteral.enterHouseViewControllerPrimaryLabel, lineHeight: 28)
         label.font = .h2
         label.textColor = .gray800
         return label
     }()
     private let enterHouseSecondaryLabel: UILabel = {
         let label = UILabel()
-        label.setTextWithLineHeight(text: "초대코드를 입력 후 바로 공간에 참여할 수 있어요!", lineHeight: 26)
+        label.setTextWithLineHeight(text: TextLiteral.enterHouseViewControllerSecondaryLabel, lineHeight: 26)
         label.font = .body1
         label.textColor = .gray400
         return label
     }()
     private let enterHouseCodeTextfield: TextField = {
         let textfield = TextField()
-        textfield.myPlaceholder = "12글자 입력"
+        textfield.myPlaceholder = TextLiteral.enterHouseViewControllerTextfieldPlaceHolder
         return textfield
     }()
     private lazy var enterHouseDoneButton: MainButton = {
@@ -115,8 +115,8 @@ final class EnterHouseViewController: BaseViewController {
     
     private func touchUpToShowToast() {
         //FIXME: - 예외 케이스에 따라 분기처리
-        showToast("잘못된 코드입니다.", 36)
-        showToast("하우스가 꽉 차서 참여할 수 없어요.\n6명까지만 참여할 수 있어요.", 56)
+        showToast(TextLiteral.enterHouseViewControllerToastWrongCode, 36)
+        showToast(TextLiteral.enterHouseViewControllerToastHouseFull, 56)
     }
     
     private func showToast(_ message: String, _ height: Int) {

--- a/fairer-iOS/fairer-iOS/Screens/EnterHouse/EnterHouseViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/EnterHouse/EnterHouseViewController.swift
@@ -14,11 +14,58 @@ final class EnterHouseViewController: BaseViewController {
     // MARK: - property
     
     private let backButton = BackButton()
+    private let enterHousePrimaryLabel: UILabel = {
+        let label = UILabel()
+        label.setTextWithLineHeight(text: "초대코드를 입력해주세요.", lineHeight: 28)
+        label.font = .h2
+        label.textColor = .gray800
+        return label
+    }()
+    private let enterHouseSecondaryLabel: UILabel = {
+        let label = UILabel()
+        label.setTextWithLineHeight(text: "초대코드를 입력 후 바로 공간에 참여할 수 있어요!", lineHeight: 26)
+        label.font = .body1
+        label.textColor = .gray400
+        return label
+    }()
+    private let enterHouseCodeTextfield: TextField = {
+        let textfield = TextField()
+        textfield.myPlaceholder = "12글자 입력"
+        return textfield
+    }()
+    private let enterHouseDoneButton: MainButton = {
+        let button = MainButton()
+        button.isDisabled = true
+        button.title = TextLiteral.doneButtonText
+        return button
+    }()
 
     // MARK: - lifecycle
     
     override func render() {
+        view.addSubview(enterHousePrimaryLabel)
+        enterHousePrimaryLabel.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(28)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+        }
         
+        view.addSubview(enterHouseSecondaryLabel)
+        enterHouseSecondaryLabel.snp.makeConstraints {
+            $0.top.equalTo(enterHousePrimaryLabel.snp.bottom)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+        }
+        
+        view.addSubview(enterHouseCodeTextfield)
+        enterHouseCodeTextfield.snp.makeConstraints {
+            $0.top.equalTo(enterHouseSecondaryLabel.snp.bottom).offset(SizeLiteral.componentPadding)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+        }
+        
+        view.addSubview(enterHouseDoneButton)
+        enterHouseDoneButton.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(SizeLiteral.componentPadding)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+        }
     }
     
     // MARK: - functions

--- a/fairer-iOS/fairer-iOS/Screens/HouseInviteCode/HouseInviteCodeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseInviteCode/HouseInviteCodeViewController.swift
@@ -14,7 +14,7 @@ final class HouseInviteCodeViewController: BaseViewController {
     // FIXME: - 사용자 지정 하우스 이름, 서버에서 받은 초대코드, 코드 유효 시간으로 변경
     let houseName: String = "즐거운 우리집"
     let inviteCode: String = "4D1AGE9HE362"
-    let validTime: Date = Calendar.current.date(byAdding: .hour, value: -1, to: Date())!
+    let validTime: Date = Calendar.current.date(byAdding: .hour, value: +1, to: Date())!
     
     // MARK: - property
     


### PR DESCRIPTION
## 📣 Related Issue
- close #36 

## 👩‍💻 Contents & Screenshot
|<img src="https://user-images.githubusercontent.com/81340603/195976666-bef6fff1-abfa-4f3a-b18e-fbdc9b8cdb32.png"/>|<img src="https://user-images.githubusercontent.com/81340603/195976669-8e3c31f4-96fb-4ff5-8ef6-ac488e5c6a78.png"/>|<img src="https://user-images.githubusercontent.com/81340603/195976672-cced45f9-047a-415c-9259-6e0408add5bd.png" />|<img src="https://user-images.githubusercontent.com/81340603/195976678-c653313d-c757-4a59-8e62-ab10794c6a31.png"/>|
|-|-|-|-|

- 기본 세팅: 디렉토리 생성, 파일 생성, navigation bar 생성
- textfield + button 넣기
- 토스트 팝업: 잘못된 코드, 최대 인원

## 📌 Review Point
서버에 참여 request 보낸 후 받을 response 구조가 어떻게 될지 아직 모르겠어서 일단 버튼 누르면 입력값과 관계없이 적용 가능한 모든 토스트 팝업 띄우도록 코드 작성했습니다! 추후 api 연결할 때 분기처리할 코드 추가할게요!

## 🔓 Next Step
- 그룹 정보 확인 화면
- 그룹 이미 참여 화면 
