### PR TITLE
[ADD] 알림 설정 뷰 UI 구현

### DIFF
--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		39F1C13028DABDE900585B83 /* HomeRuleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F1C12F28DABDE900585B83 /* HomeRuleView.swift */; };
 		39FABBDC28DB35020053EFD2 /* HomeCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39FABBDB28DB35020053EFD2 /* HomeCalendarView.swift */; };
 		5204AAB329379981002FB6CA /* ChangeHouseNameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5204AAB229379981002FB6CA /* ChangeHouseNameViewController.swift */; };
+		5204AAB629507238002FB6CA /* SettingAlarmViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5204AAB529507238002FB6CA /* SettingAlarmViewController.swift */; };
 		5205053928D6EFAF00355055 /* OnboardingNameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5205053828D6EFAF00355055 /* OnboardingNameViewController.swift */; };
 		5205053D28D7382900355055 /* UITextField+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5205053C28D7382900355055 /* UITextField+Extension.swift */; };
 		5205053F28D76B0C00355055 /* TextLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5205053E28D76B0C00355055 /* TextLiteral.swift */; };
@@ -105,6 +106,7 @@
 		39F1C12F28DABDE900585B83 /* HomeRuleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRuleView.swift; sourceTree = "<group>"; };
 		39FABBDB28DB35020053EFD2 /* HomeCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCalendarView.swift; sourceTree = "<group>"; };
 		5204AAB229379981002FB6CA /* ChangeHouseNameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeHouseNameViewController.swift; sourceTree = "<group>"; };
+		5204AAB529507238002FB6CA /* SettingAlarmViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingAlarmViewController.swift; sourceTree = "<group>"; };
 		5205053828D6EFAF00355055 /* OnboardingNameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingNameViewController.swift; sourceTree = "<group>"; };
 		5205053C28D7382900355055 /* UITextField+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Extension.swift"; sourceTree = "<group>"; };
 		5205053E28D76B0C00355055 /* TextLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLiteral.swift; sourceTree = "<group>"; };
@@ -271,6 +273,14 @@
 			path = ChangeHouseName;
 			sourceTree = "<group>";
 		};
+		5204AAB429507226002FB6CA /* SettingAlarm */ = {
+			isa = PBXGroup;
+			children = (
+				5204AAB529507238002FB6CA /* SettingAlarmViewController.swift */,
+			);
+			path = SettingAlarm;
+			sourceTree = "<group>";
+		};
 		5205053728D6EF9300355055 /* OnboardingName */ = {
 			isa = PBXGroup;
 			children = (
@@ -372,6 +382,7 @@
 		5227556C28B303370080DD65 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				5204AAB429507226002FB6CA /* SettingAlarm */,
 				5204AAB12937996F002FB6CA /* ChangeHouseName */,
 				52A673F42928955B00F3E6DA /* ManageHouse */,
 				52A673F129265EC800F3E6DA /* SettingProfileImage */,
@@ -639,6 +650,7 @@
 				39EEF67528CBB61200437654 /* String+Extension.swift in Sources */,
 				5227555428B219DC0080DD65 /* ViewController.swift in Sources */,
 				52FFDFB528FBF96900DE1AE8 /* HouseInfoViewController.swift in Sources */,
+				5204AAB629507238002FB6CA /* SettingAlarmViewController.swift in Sources */,
 				39EEF66B28CBB59400437654 /* UITableView+Extension.swift in Sources */,
 				7EFAA87328DA088900737DF0 /* SelectHouseWorkSpaceCollectionViewCell.swift in Sources */,
 				5227555028B219DC0080DD65 /* AppDelegate.swift in Sources */,

--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		39FABBDC28DB35020053EFD2 /* HomeCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39FABBDB28DB35020053EFD2 /* HomeCalendarView.swift */; };
 		5204AAB329379981002FB6CA /* ChangeHouseNameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5204AAB229379981002FB6CA /* ChangeHouseNameViewController.swift */; };
 		5204AAB629507238002FB6CA /* SettingAlarmViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5204AAB529507238002FB6CA /* SettingAlarmViewController.swift */; };
+		5204AAB929507319002FB6CA /* SettingAlarmTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5204AAB829507319002FB6CA /* SettingAlarmTableViewCell.swift */; };
 		5205053928D6EFAF00355055 /* OnboardingNameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5205053828D6EFAF00355055 /* OnboardingNameViewController.swift */; };
 		5205053D28D7382900355055 /* UITextField+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5205053C28D7382900355055 /* UITextField+Extension.swift */; };
 		5205053F28D76B0C00355055 /* TextLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5205053E28D76B0C00355055 /* TextLiteral.swift */; };
@@ -107,6 +108,7 @@
 		39FABBDB28DB35020053EFD2 /* HomeCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCalendarView.swift; sourceTree = "<group>"; };
 		5204AAB229379981002FB6CA /* ChangeHouseNameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeHouseNameViewController.swift; sourceTree = "<group>"; };
 		5204AAB529507238002FB6CA /* SettingAlarmViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingAlarmViewController.swift; sourceTree = "<group>"; };
+		5204AAB829507319002FB6CA /* SettingAlarmTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingAlarmTableViewCell.swift; sourceTree = "<group>"; };
 		5205053828D6EFAF00355055 /* OnboardingNameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingNameViewController.swift; sourceTree = "<group>"; };
 		5205053C28D7382900355055 /* UITextField+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Extension.swift"; sourceTree = "<group>"; };
 		5205053E28D76B0C00355055 /* TextLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLiteral.swift; sourceTree = "<group>"; };
@@ -276,9 +278,18 @@
 		5204AAB429507226002FB6CA /* SettingAlarm */ = {
 			isa = PBXGroup;
 			children = (
+				5204AAB7295072DE002FB6CA /* UIComponent */,
 				5204AAB529507238002FB6CA /* SettingAlarmViewController.swift */,
 			);
 			path = SettingAlarm;
+			sourceTree = "<group>";
+		};
+		5204AAB7295072DE002FB6CA /* UIComponent */ = {
+			isa = PBXGroup;
+			children = (
+				5204AAB829507319002FB6CA /* SettingAlarmTableViewCell.swift */,
+			);
+			path = UIComponent;
 			sourceTree = "<group>";
 		};
 		5205053728D6EF9300355055 /* OnboardingName */ = {
@@ -626,6 +637,7 @@
 				52DB590E29116AC8003590DF /* SettingTableViewCell.swift in Sources */,
 				7EEE2FA028E449610067FA7B /* Space.swift in Sources */,
 				39EEF68728CBB81600437654 /* BaseCollectionViewCell.swift in Sources */,
+				5204AAB929507319002FB6CA /* SettingAlarmTableViewCell.swift in Sources */,
 				520D6FF2291133A800CF65B2 /* AlreadyInGroupViewController.swift in Sources */,
 				39F1C12628D5FB4100585B83 /* UILabel+Extension.swift in Sources */,
 				5205054728D8626B00355055 /* OnboardingProfileGroupCollectionViewCell.swift in Sources */,

--- a/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
+++ b/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
@@ -106,4 +106,10 @@ enum TextLiteral {
     static let changeHouseNameViewControllerTitleLabel: String = "하우스의 이름을 입력해주세요."
     static let changeHouseNameViewControllerSecondaryLabel: String = "집의 특성을 잘 보여줄 수 있는 이름도 좋아요!"
     static let changeHouseNameViewControllerDoneButtonText: String = "입력 완료"
+    
+    // MARK: - SettingAlarmViewController
+    
+    static let settingAlarmViewControllerTimeAlarmCellText = "설정 시간에 맞춰 집안일 알림"
+    static let settingAlarmViewControllerRemindAlarmCellText = "미완료 집안일 리마인드"
+    static let settingAlarmViewControllerMorningAlarmCellText = "기본 아침 알림"
 }

--- a/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
+++ b/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let rootViewController = UINavigationController(rootViewController: SettingAlarmViewController())
+        let rootViewController = UINavigationController(rootViewController: HomeViewController())
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
     }

--- a/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
+++ b/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let rootViewController = UINavigationController(rootViewController: HomeViewController())
+        let rootViewController = UINavigationController(rootViewController: SettingAlarmViewController())
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
     }

--- a/fairer-iOS/fairer-iOS/Screens/SettingAlarm/SettingAlarmViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SettingAlarm/SettingAlarmViewController.swift
@@ -10,18 +10,46 @@ import UIKit
 import SnapKit
 
 final class SettingAlarmViewController: BaseViewController {
-
+    
     // MARK: - property
     
     private let backButton = BackButton(type: .system)
-    private let settingAlarmTableView = UITableView()
-
+    private let timeAlarmCell: SettingAlarmViewCell = {
+        let cell = SettingAlarmViewCell()
+        cell.labelText = "설정 시간에 맞춰 집안일 알림"
+        return cell
+    }()
+    private let remindAlarmCell: SettingAlarmViewCell = {
+        let cell = SettingAlarmViewCell()
+        cell.labelText = "미완료 집안일 리마인드"
+        return cell
+    }()
+    private let morningAlarmCell: SettingAlarmViewCell = {
+        let cell = SettingAlarmViewCell()
+        cell.labelText = "기본 아침 알림"
+        return cell
+    }()
+    
     // MARK: - life cycle
     
     override func render() {
-        view.addSubview(settingAlarmTableView)
-        settingAlarmTableView.snp.makeConstraints {
-            $0.top.equalToSuperview()
+        view.addSubview(timeAlarmCell)
+        timeAlarmCell.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(4)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.height.equalTo(56)
+        }
+        
+        view.addSubview(remindAlarmCell)
+        remindAlarmCell.snp.makeConstraints {
+            $0.top.equalTo(timeAlarmCell.snp.bottom)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.height.equalTo(56)
+        }
+        
+        view.addSubview(morningAlarmCell)
+        morningAlarmCell.snp.makeConstraints {
+            $0.top.equalTo(remindAlarmCell.snp.bottom)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.height.equalTo(56)
         }

--- a/fairer-iOS/fairer-iOS/Screens/SettingAlarm/SettingAlarmViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SettingAlarm/SettingAlarmViewController.swift
@@ -16,17 +16,17 @@ final class SettingAlarmViewController: BaseViewController {
     private let backButton = BackButton(type: .system)
     private let timeAlarmCell: SettingAlarmViewCell = {
         let cell = SettingAlarmViewCell()
-        cell.labelText = "설정 시간에 맞춰 집안일 알림"
+        cell.labelText = TextLiteral.settingAlarmViewControllerTimeAlarmCellText
         return cell
     }()
     private let remindAlarmCell: SettingAlarmViewCell = {
         let cell = SettingAlarmViewCell()
-        cell.labelText = "미완료 집안일 리마인드"
+        cell.labelText = TextLiteral.settingAlarmViewControllerRemindAlarmCellText
         return cell
     }()
     private let morningAlarmCell: SettingAlarmViewCell = {
         let cell = SettingAlarmViewCell()
-        cell.labelText = "기본 아침 알림"
+        cell.labelText = TextLiteral.settingAlarmViewControllerMorningAlarmCellText
         return cell
     }()
     

--- a/fairer-iOS/fairer-iOS/Screens/SettingAlarm/SettingAlarmViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SettingAlarm/SettingAlarmViewController.swift
@@ -7,6 +7,25 @@
 
 import UIKit
 
+import SnapKit
+
 final class SettingAlarmViewController: BaseViewController {
 
+    // MARK: - property
+    
+    private let backButton = BackButton(type: .system)
+
+    // MARK: - life cycle
+    
+    // MARK: - func
+    
+    override func setupNavigationBar() {
+        super.setupNavigationBar()
+        
+        let backButton = makeBarButtonItem(with: backButton)
+        
+        navigationController?.navigationBar.prefersLargeTitles = false
+        navigationItem.largeTitleDisplayMode = .never
+        navigationItem.leftBarButtonItem = backButton
+    }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SettingAlarm/SettingAlarmViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SettingAlarm/SettingAlarmViewController.swift
@@ -14,8 +14,18 @@ final class SettingAlarmViewController: BaseViewController {
     // MARK: - property
     
     private let backButton = BackButton(type: .system)
+    private let settingAlarmTableView = UITableView()
 
     // MARK: - life cycle
+    
+    override func render() {
+        view.addSubview(settingAlarmTableView)
+        settingAlarmTableView.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.height.equalTo(56)
+        }
+    }
     
     // MARK: - func
     

--- a/fairer-iOS/fairer-iOS/Screens/SettingAlarm/SettingAlarmViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SettingAlarm/SettingAlarmViewController.swift
@@ -1,0 +1,12 @@
+//
+//  SettingAlarmViewController.swift
+//  fairer-iOS
+//
+//  Created by 김유나 on 2022/12/19.
+//
+
+import UIKit
+
+final class SettingAlarmViewController: BaseViewController {
+
+}

--- a/fairer-iOS/fairer-iOS/Screens/SettingAlarm/UIComponent/SettingAlarmTableViewCell.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SettingAlarm/UIComponent/SettingAlarmTableViewCell.swift
@@ -9,13 +9,16 @@ import UIKit
 
 import SnapKit
 
-final class SettingAlarmTableViewCell: BaseTableViewCell {
+final class SettingAlarmViewCell: UIView {
+    
+    var labelText: String? {
+        didSet { setupAttribute() }
+    }
     
     // MARK: - property
     
     private let cellLabel: UILabel = {
         let label = UILabel()
-        label.text = "예시"
         label.textColor = .gray800
         label.font = .body2
         return label
@@ -24,6 +27,7 @@ final class SettingAlarmTableViewCell: BaseTableViewCell {
         let toggle = UISwitch()
         toggle.onTintColor = .blue
         toggle.isOn = false
+        toggle.transform = CGAffineTransform(scaleX: 0.9, y: 0.8)
         return toggle
     }()
     private let cellDivider: UIView = {
@@ -34,7 +38,14 @@ final class SettingAlarmTableViewCell: BaseTableViewCell {
     
     // MARK: - life cycle
     
-    override func render() {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        render()
+    }
+    
+    required init?(coder: NSCoder) { nil }
+    
+    func render() {
         self.addSubview(cellLabel)
         cellLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
@@ -52,5 +63,11 @@ final class SettingAlarmTableViewCell: BaseTableViewCell {
             $0.leading.trailing.bottom.equalToSuperview()
             $0.height.equalTo(1)
         }
+    }
+    
+    // MARK: - func
+    
+    private func setupAttribute() {
+        cellLabel.text = labelText
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SettingAlarm/UIComponent/SettingAlarmTableViewCell.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SettingAlarm/UIComponent/SettingAlarmTableViewCell.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import SnapKit
+
 final class SettingAlarmTableViewCell: BaseTableViewCell {
     
     // MARK: - property
@@ -24,4 +26,31 @@ final class SettingAlarmTableViewCell: BaseTableViewCell {
         toggle.isOn = false
         return toggle
     }()
+    private let cellDivider: UIView = {
+        let view = UIView()
+        view.backgroundColor = .gray100
+        return view
+    }()
+    
+    // MARK: - life cycle
+    
+    override func render() {
+        self.addSubview(cellLabel)
+        cellLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview()
+        }
+        
+        self.addSubview(cellToggle)
+        cellToggle.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview()
+        }
+        
+        self.addSubview(cellDivider)
+        cellDivider.snp.makeConstraints {
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.height.equalTo(1)
+        }
+    }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SettingAlarm/UIComponent/SettingAlarmTableViewCell.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SettingAlarm/UIComponent/SettingAlarmTableViewCell.swift
@@ -1,0 +1,27 @@
+//
+//  SettingAlarmTableViewCell.swift
+//  fairer-iOS
+//
+//  Created by 김유나 on 2022/12/19.
+//
+
+import UIKit
+
+final class SettingAlarmTableViewCell: BaseTableViewCell {
+    
+    // MARK: - property
+    
+    private let cellLabel: UILabel = {
+        let label = UILabel()
+        label.text = "예시"
+        label.textColor = .gray800
+        label.font = .body2
+        return label
+    }()
+    private let cellToggle: UISwitch = {
+        let toggle = UISwitch()
+        toggle.onTintColor = .blue
+        toggle.isOn = false
+        return toggle
+    }()
+}


### PR DESCRIPTION
## 📣 Related Issue
- close #51 

## 👩‍💻 Contents & Screenshot
<img src="https://user-images.githubusercontent.com/81340603/208430552-5dd164f3-2e6d-4cf7-b855-8d20d366505f.png" width=200px />
알림을 설정할 수 있는 간단한 뷰를 만들었습니다.

## 📌 Review Point
처음에 딱 봤을 때는 동일한 cell들이 list 형태로 정렬되어 있어서 당연히 table view를 사용하여 구현해야 하는 거라고 판단했습니다.
하지만 막상 구현해보니 1) cell의 reuse 의 빈도가 낮고 2) 고정된 list가 스크롤 되고 3) UISwitch가 작동하지 않는 문제들이 발생했습니다.

다시 고민해본 결과, 실현 가능한 해결 방법이 2 개 나왔습니다.
1. 보편적으로 했던 것처럼 cell 컴포넌트를 나열하여 배치한다.
2. StackView 안에서 배치해본다.

현재 PR 은 1번으로 구현되었습니다. 코드가 간단하긴 하지만 중복되는 요소들이 있어서 살짝 아쉬운 감이 있네요.
2번 방법을 사용해보고 이 피알 아래에 코멘트 남기겠습니다.

## 🧐 Question
UIStackView의 정확한 쓰임은?
그냥 autolayout 주면서 배치하는 것과 구체적으로 어떤 게 다른가?

## 🔓 Next Step
- 문의하기 화면 구현하기

## 📬 Reference
[UITableView를 쓰지 말아야 할 때]
https://soojin.ro/blog/uitableview-hype

[UISwitch resize 하기]
https://www.todaymart.com/336