### PR TITLE
[ADD] 집안일 설정 완성

### DIFF
--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		5205055828E1C50600355055 /* InfoLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5205055728E1C50600355055 /* InfoLabelView.swift */; };
 		520D6FF2291133A800CF65B2 /* AlreadyInGroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520D6FF1291133A800CF65B2 /* AlreadyInGroupViewController.swift */; };
 		52136FD4298299B90022D465 /* RepeatCycleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52136FD3298299B90022D465 /* RepeatCycleView.swift */; };
+		52136FD72983DE1A0022D465 /* RepeatCycleMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52136FD62983DE1A0022D465 /* RepeatCycleMenu.swift */; };
 		522714E8297917C3006BADBC /* SetHouseWorkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522714E7297917C3006BADBC /* SetHouseWorkViewController.swift */; };
 		522714EB297918EC006BADBC /* SetHouseWorkCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522714EA297918EC006BADBC /* SetHouseWorkCalendarView.swift */; };
 		522714ED297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522714EC297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift */; };
@@ -151,6 +152,7 @@
 		5205055728E1C50600355055 /* InfoLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoLabelView.swift; sourceTree = "<group>"; };
 		520D6FF1291133A800CF65B2 /* AlreadyInGroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlreadyInGroupViewController.swift; sourceTree = "<group>"; };
 		52136FD3298299B90022D465 /* RepeatCycleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatCycleView.swift; sourceTree = "<group>"; };
+		52136FD62983DE1A0022D465 /* RepeatCycleMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatCycleMenu.swift; sourceTree = "<group>"; };
 		522714E7297917C3006BADBC /* SetHouseWorkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetHouseWorkViewController.swift; sourceTree = "<group>"; };
 		522714EA297918EC006BADBC /* SetHouseWorkCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetHouseWorkCalendarView.swift; sourceTree = "<group>"; };
 		522714EC297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetHouseWorkCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -439,6 +441,7 @@
 			isa = PBXGroup;
 			children = (
 				52136FD3298299B90022D465 /* RepeatCycleView.swift */,
+				52136FD62983DE1A0022D465 /* RepeatCycleMenu.swift */,
 			);
 			path = RepeatCycle;
 			sourceTree = "<group>";
@@ -810,6 +813,7 @@
 				39EEF66D28CBB59D00437654 /* UICollectionView+Extension.swift in Sources */,
 				39EEF67728CBB61600437654 /* Date+Extension.swift in Sources */,
 				39EEF66928CBB57F00437654 /* UIViewController+Extension.swift in Sources */,
+				52136FD72983DE1A0022D465 /* RepeatCycleMenu.swift in Sources */,
 				7EF87A3828E1A17800DFE353 /* SpaceNameLabel.swift in Sources */,
 				52DB590E29116AC8003590DF /* SettingTableViewCell.swift in Sources */,
 				7EEE2FA028E449610067FA7B /* Space.swift in Sources */,

--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		520D6FF2291133A800CF65B2 /* AlreadyInGroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520D6FF1291133A800CF65B2 /* AlreadyInGroupViewController.swift */; };
 		52136FD4298299B90022D465 /* RepeatCycleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52136FD3298299B90022D465 /* RepeatCycleView.swift */; };
 		52136FD72983DE1A0022D465 /* RepeatCycleMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52136FD62983DE1A0022D465 /* RepeatCycleMenu.swift */; };
+		52136FD92983E87F0022D465 /* RepeatCycleCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52136FD82983E87F0022D465 /* RepeatCycleCollectionViewCell.swift */; };
 		522714E8297917C3006BADBC /* SetHouseWorkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522714E7297917C3006BADBC /* SetHouseWorkViewController.swift */; };
 		522714EB297918EC006BADBC /* SetHouseWorkCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522714EA297918EC006BADBC /* SetHouseWorkCalendarView.swift */; };
 		522714ED297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522714EC297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift */; };
@@ -153,6 +154,7 @@
 		520D6FF1291133A800CF65B2 /* AlreadyInGroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlreadyInGroupViewController.swift; sourceTree = "<group>"; };
 		52136FD3298299B90022D465 /* RepeatCycleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatCycleView.swift; sourceTree = "<group>"; };
 		52136FD62983DE1A0022D465 /* RepeatCycleMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatCycleMenu.swift; sourceTree = "<group>"; };
+		52136FD82983E87F0022D465 /* RepeatCycleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatCycleCollectionViewCell.swift; sourceTree = "<group>"; };
 		522714E7297917C3006BADBC /* SetHouseWorkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetHouseWorkViewController.swift; sourceTree = "<group>"; };
 		522714EA297918EC006BADBC /* SetHouseWorkCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetHouseWorkCalendarView.swift; sourceTree = "<group>"; };
 		522714EC297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetHouseWorkCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -442,6 +444,7 @@
 			children = (
 				52136FD3298299B90022D465 /* RepeatCycleView.swift */,
 				52136FD62983DE1A0022D465 /* RepeatCycleMenu.swift */,
+				52136FD82983E87F0022D465 /* RepeatCycleCollectionViewCell.swift */,
 			);
 			path = RepeatCycle;
 			sourceTree = "<group>";
@@ -822,6 +825,7 @@
 				39EEF68728CBB81600437654 /* BaseCollectionViewCell.swift in Sources */,
 				5204AAC62962D281002FB6CA /* SelectHouseWorkCalendarView.swift in Sources */,
 				52136FD4298299B90022D465 /* RepeatCycleView.swift in Sources */,
+				52136FD92983E87F0022D465 /* RepeatCycleCollectionViewCell.swift in Sources */,
 				522714ED297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift in Sources */,
 				5204AAB929507319002FB6CA /* SettingAlarmTableViewCell.swift in Sources */,
 				520D6FF2291133A800CF65B2 /* AlreadyInGroupViewController.swift in Sources */,

--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		52136FD4298299B90022D465 /* RepeatCycleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52136FD3298299B90022D465 /* RepeatCycleView.swift */; };
 		52136FD72983DE1A0022D465 /* RepeatCycleMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52136FD62983DE1A0022D465 /* RepeatCycleMenu.swift */; };
 		52136FD92983E87F0022D465 /* RepeatCycleCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52136FD82983E87F0022D465 /* RepeatCycleCollectionViewCell.swift */; };
+		52136FDB2983E9920022D465 /* RepeatCycleCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52136FDA2983E9920022D465 /* RepeatCycleCollectionView.swift */; };
 		522714E8297917C3006BADBC /* SetHouseWorkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522714E7297917C3006BADBC /* SetHouseWorkViewController.swift */; };
 		522714EB297918EC006BADBC /* SetHouseWorkCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522714EA297918EC006BADBC /* SetHouseWorkCalendarView.swift */; };
 		522714ED297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522714EC297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift */; };
@@ -155,6 +156,7 @@
 		52136FD3298299B90022D465 /* RepeatCycleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatCycleView.swift; sourceTree = "<group>"; };
 		52136FD62983DE1A0022D465 /* RepeatCycleMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatCycleMenu.swift; sourceTree = "<group>"; };
 		52136FD82983E87F0022D465 /* RepeatCycleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatCycleCollectionViewCell.swift; sourceTree = "<group>"; };
+		52136FDA2983E9920022D465 /* RepeatCycleCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatCycleCollectionView.swift; sourceTree = "<group>"; };
 		522714E7297917C3006BADBC /* SetHouseWorkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetHouseWorkViewController.swift; sourceTree = "<group>"; };
 		522714EA297918EC006BADBC /* SetHouseWorkCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetHouseWorkCalendarView.swift; sourceTree = "<group>"; };
 		522714EC297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetHouseWorkCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -445,6 +447,7 @@
 				52136FD3298299B90022D465 /* RepeatCycleView.swift */,
 				52136FD62983DE1A0022D465 /* RepeatCycleMenu.swift */,
 				52136FD82983E87F0022D465 /* RepeatCycleCollectionViewCell.swift */,
+				52136FDA2983E9920022D465 /* RepeatCycleCollectionView.swift */,
 			);
 			path = RepeatCycle;
 			sourceTree = "<group>";
@@ -882,6 +885,7 @@
 				52EBF04928E578850062EB41 /* HouseMakeNameViewController.swift in Sources */,
 				39F1C13028DABDE900585B83 /* HomeRuleView.swift in Sources */,
 				39EEF66528CBB4C800437654 /* UIColor+Extension.swift in Sources */,
+				52136FDB2983E9920022D465 /* RepeatCycleCollectionView.swift in Sources */,
 				7EFAA87128DA04FB00737DF0 /* SelectHouseWorkSpaceCollectionView.swift in Sources */,
 				39EEF67928CBB64500437654 /* UIButton+Extension.swift in Sources */,
 				911455C0297E7FD7002CCDF9 /* WorkState.swift in Sources */,

--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		52136FD72983DE1A0022D465 /* RepeatCycleMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52136FD62983DE1A0022D465 /* RepeatCycleMenu.swift */; };
 		52136FD92983E87F0022D465 /* RepeatCycleCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52136FD82983E87F0022D465 /* RepeatCycleCollectionViewCell.swift */; };
 		52136FDB2983E9920022D465 /* RepeatCycleCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52136FDA2983E9920022D465 /* RepeatCycleCollectionView.swift */; };
+		52136FDE29867AB60022D465 /* HouseWork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52136FDD29867AB60022D465 /* HouseWork.swift */; };
 		522714E8297917C3006BADBC /* SetHouseWorkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522714E7297917C3006BADBC /* SetHouseWorkViewController.swift */; };
 		522714EB297918EC006BADBC /* SetHouseWorkCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522714EA297918EC006BADBC /* SetHouseWorkCalendarView.swift */; };
 		522714ED297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522714EC297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift */; };
@@ -157,6 +158,7 @@
 		52136FD62983DE1A0022D465 /* RepeatCycleMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatCycleMenu.swift; sourceTree = "<group>"; };
 		52136FD82983E87F0022D465 /* RepeatCycleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatCycleCollectionViewCell.swift; sourceTree = "<group>"; };
 		52136FDA2983E9920022D465 /* RepeatCycleCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatCycleCollectionView.swift; sourceTree = "<group>"; };
+		52136FDD29867AB60022D465 /* HouseWork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HouseWork.swift; sourceTree = "<group>"; };
 		522714E7297917C3006BADBC /* SetHouseWorkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetHouseWorkViewController.swift; sourceTree = "<group>"; };
 		522714EA297918EC006BADBC /* SetHouseWorkCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetHouseWorkCalendarView.swift; sourceTree = "<group>"; };
 		522714EC297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetHouseWorkCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -452,9 +454,18 @@
 			path = RepeatCycle;
 			sourceTree = "<group>";
 		};
+		52136FDC29867A810022D465 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				52136FDD29867AB60022D465 /* HouseWork.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		522714E6297917AF006BADBC /* SetHouseWork */ = {
 			isa = PBXGroup;
 			children = (
+				52136FDC29867A810022D465 /* Model */,
 				522714E9297918DB006BADBC /* UIComponent */,
 				522714E7297917C3006BADBC /* SetHouseWorkViewController.swift */,
 			);
@@ -837,6 +848,7 @@
 				52E4C083297CE586002AC755 /* MemberCollectionViewCell.swift in Sources */,
 				5205055428E1BF6700355055 /* GroupMainViewController.swift in Sources */,
 				522E88FF28EC854C000C65C8 /* InviteCodeView.swift in Sources */,
+				52136FDE29867AB60022D465 /* HouseWork.swift in Sources */,
 				52C09CF329115FC300B46F15 /* SettingViewController.swift in Sources */,
 				39F1C12128D5A80400585B83 /* HomeViewController.swift in Sources */,
 				5205055128DCB63D00355055 /* LoginViewController.swift in Sources */,

--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		5205055428E1BF6700355055 /* GroupMainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5205055328E1BF6700355055 /* GroupMainViewController.swift */; };
 		5205055828E1C50600355055 /* InfoLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5205055728E1C50600355055 /* InfoLabelView.swift */; };
 		520D6FF2291133A800CF65B2 /* AlreadyInGroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520D6FF1291133A800CF65B2 /* AlreadyInGroupViewController.swift */; };
+		52136FD4298299B90022D465 /* RepeatCycleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52136FD3298299B90022D465 /* RepeatCycleView.swift */; };
 		522714E8297917C3006BADBC /* SetHouseWorkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522714E7297917C3006BADBC /* SetHouseWorkViewController.swift */; };
 		522714EB297918EC006BADBC /* SetHouseWorkCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522714EA297918EC006BADBC /* SetHouseWorkCalendarView.swift */; };
 		522714ED297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522714EC297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift */; };
@@ -149,6 +150,7 @@
 		5205055328E1BF6700355055 /* GroupMainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupMainViewController.swift; sourceTree = "<group>"; };
 		5205055728E1C50600355055 /* InfoLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoLabelView.swift; sourceTree = "<group>"; };
 		520D6FF1291133A800CF65B2 /* AlreadyInGroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlreadyInGroupViewController.swift; sourceTree = "<group>"; };
+		52136FD3298299B90022D465 /* RepeatCycleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatCycleView.swift; sourceTree = "<group>"; };
 		522714E7297917C3006BADBC /* SetHouseWorkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetHouseWorkViewController.swift; sourceTree = "<group>"; };
 		522714EA297918EC006BADBC /* SetHouseWorkCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetHouseWorkCalendarView.swift; sourceTree = "<group>"; };
 		522714EC297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetHouseWorkCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -433,6 +435,14 @@
 			path = AlreadyInGroup;
 			sourceTree = "<group>";
 		};
+		52136FD5298299BD0022D465 /* RepeatCycle */ = {
+			isa = PBXGroup;
+			children = (
+				52136FD3298299B90022D465 /* RepeatCycleView.swift */,
+			);
+			path = RepeatCycle;
+			sourceTree = "<group>";
+		};
 		522714E6297917AF006BADBC /* SetHouseWork */ = {
 			isa = PBXGroup;
 			children = (
@@ -445,6 +455,7 @@
 		522714E9297918DB006BADBC /* UIComponent */ = {
 			isa = PBXGroup;
 			children = (
+				52136FD5298299BD0022D465 /* RepeatCycle */,
 				522714EA297918EC006BADBC /* SetHouseWorkCalendarView.swift */,
 				522714EC297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift */,
 				522714EE29792936006BADBC /* SetHouseWorkCollectionView.swift */,
@@ -806,6 +817,7 @@
 				5204AAC82963150F002FB6CA /* WriteHouseWorkButton.swift in Sources */,
 				39EEF68728CBB81600437654 /* BaseCollectionViewCell.swift in Sources */,
 				5204AAC62962D281002FB6CA /* SelectHouseWorkCalendarView.swift in Sources */,
+				52136FD4298299B90022D465 /* RepeatCycleView.swift in Sources */,
 				522714ED297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift in Sources */,
 				5204AAB929507319002FB6CA /* SettingAlarmTableViewCell.swift in Sources */,
 				520D6FF2291133A800CF65B2 /* AlreadyInGroupViewController.swift in Sources */,

--- a/fairer-iOS/fairer-iOS/Global/Extension/Date+Extension.swift
+++ b/fairer-iOS/fairer-iOS/Global/Extension/Date+Extension.swift
@@ -58,7 +58,7 @@ extension Date {
     
     var timeToKoreanString: String {
         let formatter = DateFormatter()
-        formatter.dateFormat = "a\n h시 m분"
+        formatter.dateFormat = "a\nh시 m분"
         return formatter.string(from: self)
     }
     

--- a/fairer-iOS/fairer-iOS/Global/Extension/Date+Extension.swift
+++ b/fairer-iOS/fairer-iOS/Global/Extension/Date+Extension.swift
@@ -56,4 +56,9 @@ extension Date {
         return Calendar.current.date(byAdding: .second, value: 604799, to: self.startOfWeek)!
     }
     
+    var timeToKoreanString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "a\n h시 m분"
+        return formatter.string(from: self)
+    }
 }

--- a/fairer-iOS/fairer-iOS/Global/Extension/Date+Extension.swift
+++ b/fairer-iOS/fairer-iOS/Global/Extension/Date+Extension.swift
@@ -68,4 +68,11 @@ extension Date {
         formatter.dateFormat = "E"
         return formatter.string(from: self)
     }
+    
+    var singleDayToKoreanString: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier:"ko_KR")
+        formatter.dateFormat = "d일"
+        return formatter.string(from: self)
+    }
 }

--- a/fairer-iOS/fairer-iOS/Global/Extension/Date+Extension.swift
+++ b/fairer-iOS/fairer-iOS/Global/Extension/Date+Extension.swift
@@ -61,4 +61,11 @@ extension Date {
         formatter.dateFormat = "a\n h시 m분"
         return formatter.string(from: self)
     }
+    
+    var dayOfWeekToKoreanString: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier:"ko_KR")
+        formatter.dateFormat = "E"
+        return formatter.string(from: self)
+    }
 }

--- a/fairer-iOS/fairer-iOS/Global/Extension/Date+Extension.swift
+++ b/fairer-iOS/fairer-iOS/Global/Extension/Date+Extension.swift
@@ -72,7 +72,7 @@ extension Date {
     var singleDayToKoreanString: String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier:"ko_KR")
-        formatter.dateFormat = "d일"
+        formatter.dateFormat = "d"
         return formatter.string(from: self)
     }
 }

--- a/fairer-iOS/fairer-iOS/Global/Literal/ImageLiteral.swift
+++ b/fairer-iOS/fairer-iOS/Global/Literal/ImageLiteral.swift
@@ -65,6 +65,7 @@ enum ImageLiterals {
     static var plusWorkButton: UIImage { .load(systemName: "plus") }
     static var moveToCalendarButton: UIImage { .load(name: "keyboard_arrow_down") }
     static var addManagerButton: UIImage { .load(name: "managerplus") }
+    static var repeatCycleChevronButton: UIImage { .load(name: "repeatcyclechevron") }
     
     // MARK: - icon
     

--- a/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
+++ b/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
@@ -165,7 +165,7 @@ enum TextLiteral {
     
     // MARK: - RepeatCycleCollectionView
     
-    static let repeatCycleCollectionViewDaysOfWeekList = ["월", "화", "수", "목", "금", "토", "일"]
+    static let repeatCycleCollectionViewDaysOfWeekList = ["0월", "1화", "2수", "3목", "4금", "5토", "6일"]
     
     // MARK: - SetHouseWorkViewController
     

--- a/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
+++ b/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
@@ -144,7 +144,6 @@ enum TextLiteral {
     
     static let writeHouseWorkButtonLabel = "집안일 직접 입력하기"
     
-    
     // MARK: - SetHouseWorkCollectionViewCell
     
     static let setHouseWorkCollectionViewCellDefaultTimeLabel = "하루 종일"
@@ -159,4 +158,24 @@ enum TextLiteral {
     // MARK: - GetManagerView
     
     static let getManagerViewManagerLabel = "담당자"
+    
+    // MARK: - RepeatCycleView
+    
+    static let repeatCycleViewRepeatCycleLabel = "반복주기"
+    
+    // MARK: - RepeatCycleCollectionView
+    
+    static let repeatCycleCollectionViewDaysOfWeekList = ["월", "화", "수", "목", "금", "토", "일"]
+    
+    // MARK: - SetHouseWorkViewController
+    
+    static let setHouseWorkViewControllerSetTimeLabel = "시간설정"
+    static let setHouseWorkViewControllerSetRepeatLabel = "반복하기"
+    static let setHouseWorkViewControllerDoneButtonText = "집안일 추가 완료"
+    static let setHouseWorkViewControllerEveryWeek = "매주 "
+    static let setHouseWorkViewControllerWeek = "요일"
+    static let setHouseWorkViewControllerEveryMonth = "매달 "
+    static let setHouseWorkViewControllerDay = "일"
+    static let setHouseWorkViewControllerRepeat = "에 반복해요"
+    
 }

--- a/fairer-iOS/fairer-iOS/Global/Resource/Assets.xcassets/button/repeatcyclechevron.imageset/Contents.json
+++ b/fairer-iOS/fairer-iOS/Global/Resource/Assets.xcassets/button/repeatcyclechevron.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "repeatcyclechevron.pdf",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/fairer-iOS/fairer-iOS/Global/Resource/Assets.xcassets/button/repeatcyclechevron.imageset/repeatcyclechevron.pdf
+++ b/fairer-iOS/fairer-iOS/Global/Resource/Assets.xcassets/button/repeatcyclechevron.imageset/repeatcyclechevron.pdf
@@ -1,0 +1,73 @@
+%PDF-1.7
+
+1 0 obj
+  << >>
+endobj
+
+2 0 obj
+  << /Length 3 0 R >>
+stream
+/DeviceRGB CS
+/DeviceRGB cs
+q
+1.000000 0.000000 -0.000000 1.000000 4.000000 5.333496 cm
+0.701961 0.701961 0.701961 scn
+7.060000 4.939941 m
+4.000000 1.886608 l
+0.940000 4.939941 l
+0.000000 3.999941 l
+4.000000 -0.000059 l
+8.000000 3.999941 l
+7.060000 4.939941 l
+h
+f
+n
+Q
+
+endstream
+endobj
+
+3 0 obj
+  268
+endobj
+
+4 0 obj
+  << /Annots []
+     /Type /Page
+     /MediaBox [ 0.000000 0.000000 16.000000 16.000000 ]
+     /Resources 1 0 R
+     /Contents 2 0 R
+     /Parent 5 0 R
+  >>
+endobj
+
+5 0 obj
+  << /Kids [ 4 0 R ]
+     /Count 1
+     /Type /Pages
+  >>
+endobj
+
+6 0 obj
+  << /Pages 5 0 R
+     /Type /Catalog
+  >>
+endobj
+
+xref
+0 7
+0000000000 65535 f
+0000000010 00000 n
+0000000034 00000 n
+0000000358 00000 n
+0000000380 00000 n
+0000000553 00000 n
+0000000627 00000 n
+trailer
+<< /ID [ (some) (id) ]
+   /Root 6 0 R
+   /Size 7
+>>
+startxref
+686
+%%EOF

--- a/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
+++ b/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let rootViewController = UINavigationController(rootViewController: HomeViewController())
+        let rootViewController = UINavigationController(rootViewController: SetHouseWorkViewController())
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
     }

--- a/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
+++ b/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let rootViewController = UINavigationController(rootViewController: SetHouseWorkViewController())
+        let rootViewController = UINavigationController(rootViewController: HomeViewController())
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
     }

--- a/fairer-iOS/fairer-iOS/Global/UIComponent/GetManagerView/GetManagerCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Global/UIComponent/GetManagerView/GetManagerCollectionView.swift
@@ -12,9 +12,6 @@ import SnapKit
 final class GetManagerCollectionView: BaseUIView {
     
     // FIXME: - 담당자 리스트 받아오기
-//    var selectedMemberList: [String] = ["고가혜"] {
-//        didSet { collectionView.reloadData() }
-//    }
     var selectedMemberList: [String] = HouseWork.mockHouseWork[0].manager {
         didSet { collectionView.reloadData() }
     }

--- a/fairer-iOS/fairer-iOS/Global/UIComponent/GetManagerView/GetManagerCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Global/UIComponent/GetManagerView/GetManagerCollectionView.swift
@@ -12,7 +12,10 @@ import SnapKit
 final class GetManagerCollectionView: BaseUIView {
     
     // FIXME: - 담당자 리스트 받아오기
-    var selectedMemberList: [String] = ["고가혜"] {
+//    var selectedMemberList: [String] = ["고가혜"] {
+//        didSet { collectionView.reloadData() }
+//    }
+    var selectedMemberList: [String] = HouseWork.mockHouseWork[0].manager {
         didSet { collectionView.reloadData() }
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/Model/HouseWork.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/Model/HouseWork.swift
@@ -13,8 +13,8 @@ struct HouseWork {
     var time: String
     let space: String
     var manager: [String]
-    let repeatCycle: String?
-    let repeatPattern: String?
+    var repeatCycle: String?
+    var repeatPattern: [String]?
     
     #if DEBUG
     static var mockHouseWork: [HouseWork] = [

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/Model/HouseWork.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/Model/HouseWork.swift
@@ -1,0 +1,30 @@
+//
+//  HouseWork.swift
+//  fairer-iOS
+//
+//  Created by 김유나 on 2023/01/29.
+//
+
+import UIKit
+
+struct HouseWork {
+    let name: String
+    let date: Date
+    let time: Date?
+    let space: String
+    let manager: [String]
+    let repeatCycle: String?
+    let repeatPattern: String?
+    
+    #if DEBUG
+    static let mockHouseWork: [HouseWork] = [
+        HouseWork(name: "창 청소", date: Date(), time: nil, space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
+        HouseWork(name: "거실 청소", date: Date(), time: nil, space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
+        HouseWork(name: "물건 정리정돈", date: Date(), time: nil, space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
+        HouseWork(name: "환기 시키기", date: Date(), time: nil, space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
+        HouseWork(name: "빨래 돌리기", date: Date(), time: nil, space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
+        HouseWork(name: "빨래 개기", date: Date(), time: nil, space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
+        HouseWork(name: "세탁기 청소", date: Date(), time: nil, space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil)
+    ]
+    #endif
+}

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/Model/HouseWork.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/Model/HouseWork.swift
@@ -12,12 +12,12 @@ struct HouseWork {
     let date: Date
     let time: Date?
     let space: String
-    let manager: [String]
+    var manager: [String]
     let repeatCycle: String?
     let repeatPattern: String?
     
     #if DEBUG
-    static let mockHouseWork: [HouseWork] = [
+    static var mockHouseWork: [HouseWork] = [
         HouseWork(name: "창 청소", date: Date(), time: nil, space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
         HouseWork(name: "거실 청소", date: Date(), time: nil, space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
         HouseWork(name: "물건 정리정돈", date: Date(), time: nil, space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/Model/HouseWork.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/Model/HouseWork.swift
@@ -13,7 +13,7 @@ struct HouseWork {
     var time: String
     let space: String
     var manager: [String]
-    var repeatCycle: String?
+    var repeatCycle: RepeatType?
     var repeatPattern: [String]?
     
     #if DEBUG

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/Model/HouseWork.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/Model/HouseWork.swift
@@ -10,7 +10,7 @@ import UIKit
 struct HouseWork {
     let name: String
     let date: Date
-    let time: Date?
+    var time: String
     let space: String
     var manager: [String]
     let repeatCycle: String?
@@ -18,13 +18,13 @@ struct HouseWork {
     
     #if DEBUG
     static var mockHouseWork: [HouseWork] = [
-        HouseWork(name: "창 청소", date: Date(), time: nil, space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
-        HouseWork(name: "거실 청소", date: Date(), time: nil, space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
-        HouseWork(name: "물건 정리정돈", date: Date(), time: nil, space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
-        HouseWork(name: "환기 시키기", date: Date(), time: nil, space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
-        HouseWork(name: "빨래 돌리기", date: Date(), time: nil, space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
-        HouseWork(name: "빨래 개기", date: Date(), time: nil, space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
-        HouseWork(name: "세탁기 청소", date: Date(), time: nil, space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil)
+        HouseWork(name: "창 청소", date: Date(), time: "하루 종일", space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
+        HouseWork(name: "거실 청소", date: Date(), time: "하루 종일", space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
+        HouseWork(name: "물건 정리정돈", date: Date(), time: "하루 종일", space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
+        HouseWork(name: "환기 시키기", date: Date(), time: "하루 종일", space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
+        HouseWork(name: "빨래 돌리기", date: Date(), time: "하루 종일", space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
+        HouseWork(name: "빨래 개기", date: Date(), time: "하루 종일", space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil),
+        HouseWork(name: "세탁기 청소", date: Date(), time: "하루 종일", space: "거실", manager: ["고가혜"], repeatCycle: nil, repeatPattern: nil)
     ]
     #endif
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -101,6 +101,14 @@ final class SetHouseWorkViewController: BaseViewController {
         toggle.addAction(action, for: .touchUpInside)
         return toggle
     }()
+    private lazy var repeatCycleView: RepeatCycleView = {
+        let view = RepeatCycleView()
+        let action = UIAction { [weak self] _ in
+            self?.didTappedRepeatCycleButton()
+        }
+        view.repeatCycleButton.addAction(action, for: .touchUpInside)
+        return view
+    }()
     
     // MARK: - life cycle
     
@@ -142,7 +150,7 @@ final class SetHouseWorkViewController: BaseViewController {
         
         view.addSubview(setTimeLabel)
         setTimeLabel.snp.makeConstraints {
-            $0.top.equalTo(getManagerView.snp.bottom).offset(16)
+            $0.top.equalTo(getManagerView.snp.bottom).offset(SizeLiteral.componentPadding)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
@@ -161,14 +169,14 @@ final class SetHouseWorkViewController: BaseViewController {
         
         view.addSubview(divider)
         divider.snp.makeConstraints {
-            $0.top.equalTo(timePicker.snp.bottom).offset(16)
+            $0.top.equalTo(timePicker.snp.bottom).offset(SizeLiteral.componentPadding)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.height.equalTo(2)
         }
         
         view.addSubview(setRepeatLabel)
         setRepeatLabel.snp.makeConstraints {
-            $0.top.equalTo(divider.snp.bottom).offset(16)
+            $0.top.equalTo(divider.snp.bottom).offset(SizeLiteral.componentPadding)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
@@ -176,6 +184,13 @@ final class SetHouseWorkViewController: BaseViewController {
         setRepeatToggle.snp.makeConstraints {
             $0.centerY.equalTo(setRepeatLabel.snp.centerY)
             $0.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+        }
+        
+        view.addSubview(repeatCycleView)
+        repeatCycleView.snp.makeConstraints {
+            $0.top.equalTo(setRepeatLabel.snp.bottom).offset(SizeLiteral.componentPadding)
+            $0.leading.trailing.equalToSuperview().inset(31.5)
+            $0.height.equalTo(36)
         }
     }
     
@@ -271,5 +286,9 @@ final class SetHouseWorkViewController: BaseViewController {
         let date = timePicker.date.timeToKoreanString
         // FIXME: - 모델 생성 후 CollectionView에 시간 반영
         print(date)
+    }
+    
+    private func didTappedRepeatCycleButton() {
+        print("누름")
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -317,7 +317,7 @@ final class SetHouseWorkViewController: BaseViewController {
                 self?.repeatCycleView.repeatCycleLabel.isHidden = false
                 self?.repeatCycleDayLabel.isHidden = false
                 
-                if HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle == "매주" {
+                if HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle == RepeatType.week {
                     self?.repeatCycleCollectionView.snp.updateConstraints {
                         $0.height.equalTo(40)
                     }
@@ -434,11 +434,13 @@ final class SetHouseWorkViewController: BaseViewController {
                 $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             }
             updateToWeekToday()
-            HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle = "매주"
+            HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle = RepeatType.week
             
             UIView.animate(withDuration: 0.3, delay: 0, options: .allowAnimatedContent, animations: {
                 self.view.layoutIfNeeded()
             }, completion: nil)
+            
+            // FIXME: - Calendar View 비활성화 (개발되면 변경)
         } else {
             repeatCycleView.snp.updateConstraints {
                 $0.height.equalTo(0)
@@ -473,22 +475,22 @@ final class SetHouseWorkViewController: BaseViewController {
     
     private func didTappedRepeatCycleMenuButton() {
         repeatCycleMenu.didTappedRepeatCycleMenuButton = { [weak self] repeatCycle in
-            if repeatCycle == "매달" {
+            if repeatCycle == .month {
                 self?.repeatCycleCollectionView.snp.updateConstraints {
                     $0.height.equalTo(0)
                 }
                 
                 self?.updateToMonthToday()
-                HouseWork.mockHouseWork[self?.selectedHouseWorkIndex ?? 0].repeatCycle = "매달"
+                HouseWork.mockHouseWork[self?.selectedHouseWorkIndex ?? 0].repeatCycle = repeatCycle
             } else {
                 self?.repeatCycleCollectionView.snp.updateConstraints {
                     $0.height.equalTo(40)
                 }
                 
                 self?.updateToWeekToday()
-                HouseWork.mockHouseWork[self?.selectedHouseWorkIndex ?? 0].repeatCycle = "매주"
+                HouseWork.mockHouseWork[self?.selectedHouseWorkIndex ?? 0].repeatCycle = repeatCycle
             }
-            self?.repeatCycleView.repeatCycleButtonLabel.text = repeatCycle
+            self?.repeatCycleView.repeatCycleButtonLabel.text = repeatCycle.rawValue
             self?.repeatCycleMenu.isHidden = true
         }
     }
@@ -548,7 +550,7 @@ final class SetHouseWorkViewController: BaseViewController {
             repeatCycleView.repeatCycleLabel.isHidden = false
             repeatCycleDayLabel.isHidden = false
             
-            if HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle == "매주" {
+            if HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle == RepeatType.week {
                 repeatCycleCollectionView.snp.updateConstraints {
                     $0.height.equalTo(40)
                 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -266,6 +266,18 @@ final class SetHouseWorkViewController: BaseViewController {
             self?.selectManagerView.snp.updateConstraints {
                 $0.height.equalTo(0)
             }
+            
+            if HouseWork.mockHouseWork[selectedHouseWorkIndex].time == "하루 종일" {
+                self?.setTimeToggle.isOn = false
+                self?.timePicker.snp.updateConstraints {
+                    $0.height.equalTo(0)
+                }
+            } else {
+                self?.setTimeToggle.isOn = true
+                self?.timePicker.snp.updateConstraints {
+                    $0.height.equalTo(196.2)
+                }
+            }
         }
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -311,23 +311,15 @@ final class SetHouseWorkViewController: BaseViewController {
             } else if deletedHouseWorkIndex == HouseWork.mockHouseWork.endIndex && deletedHouseWorkIndex == self?.selectedHouseWorkIndex ?? 0 {
                 self?.selectedHouseWorkIndex -= 1
                 self?.repeatCycleCollectionView.selectedHouseWorkIndex -= 1
-                self?.getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[deletedHouseWorkIndex - 1].manager
-                self?.isTimeSelected(deletedHouseWorkIndex - 1)
-                self?.isRepeatSelected(deletedHouseWorkIndex - 1)
+                self?.updateManagerTimeRepeat(deletedHouseWorkIndex - 1)
             } else if deletedHouseWorkIndex < self?.selectedHouseWorkIndex ?? 0 {
                 self?.selectedHouseWorkIndex -= 1
                 self?.repeatCycleCollectionView.selectedHouseWorkIndex -= 1
-                self?.getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[self?.selectedHouseWorkIndex ?? 0].manager
-                self?.isTimeSelected(self?.selectedHouseWorkIndex ?? 0)
-                self?.isRepeatSelected(self?.selectedHouseWorkIndex ?? 0)
+                self?.updateManagerTimeRepeat(self?.selectedHouseWorkIndex ?? 0)
             } else if deletedHouseWorkIndex == self?.selectedHouseWorkIndex {
-                self?.getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[deletedHouseWorkIndex].manager
-                self?.isTimeSelected(deletedHouseWorkIndex)
-                self?.isRepeatSelected(deletedHouseWorkIndex)
+                self?.updateManagerTimeRepeat(deletedHouseWorkIndex)
             } else {
-                self?.getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[self?.selectedHouseWorkIndex ?? 0].manager
-                self?.isTimeSelected(self?.selectedHouseWorkIndex ?? 0)
-                self?.isRepeatSelected(self?.selectedHouseWorkIndex ?? 0)
+                self?.updateManagerTimeRepeat(self?.selectedHouseWorkIndex ?? 0)
             }
         }
     }
@@ -533,5 +525,11 @@ final class SetHouseWorkViewController: BaseViewController {
                 updateToMonthToday()
             }
         }
+    }
+    
+    private func updateManagerTimeRepeat(_ houseWork: Int) {
+        getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[houseWork].manager
+        isTimeSelected(houseWork)
+        isRepeatSelected(houseWork)
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -211,9 +211,9 @@ final class SetHouseWorkViewController: BaseViewController {
         
         view.addSubview(repeatCycleCollectionView)
         repeatCycleCollectionView.snp.makeConstraints {
-            $0.top.equalTo(repeatCycleView.snp.bottom)
+            $0.top.equalTo(repeatCycleView.snp.bottom).offset(8)
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(56)
+            $0.height.equalTo(40)
         }
         
         view.addSubview(repeatCycleMenu)
@@ -226,7 +226,7 @@ final class SetHouseWorkViewController: BaseViewController {
         
         view.addSubview(repeatCycleDayLabel)
         repeatCycleDayLabel.snp.makeConstraints {
-            $0.top.equalTo(repeatCycleCollectionView.snp.bottom).offset(8)
+            $0.top.equalTo(repeatCycleCollectionView.snp.bottom).offset(16)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
     }
@@ -335,10 +335,17 @@ final class SetHouseWorkViewController: BaseViewController {
                 self?.repeatCycleCollectionView.snp.updateConstraints {
                     $0.height.equalTo(0)
                 }
+                
+                self?.repeatCycleDayLabel.text = "매달 " + Date().singleDayToKoreanString + "에 반복해요"
+                self?.repeatCycleDayLabel.applyColor(to: Date().singleDayToKoreanString, with: .positive20)
+                self?.repeatCycleCollectionView.selectedDaysOfWeek = []
             } else {
                 self?.repeatCycleCollectionView.snp.updateConstraints {
-                    $0.height.equalTo(56)
+                    $0.height.equalTo(40)
                 }
+                
+                self?.repeatCycleDayLabel.text = "매주 " + Date().dayOfWeekToKoreanString + "요일에 반복해요"
+                self?.repeatCycleDayLabel.applyColor(to: Date().dayOfWeekToKoreanString, with: .positive20)
             }
             self?.repeatCycleView.repeatCycleButtonLabel.text = repeatCycle
             self?.repeatCycleMenu.isHidden = true

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -48,6 +48,39 @@ final class SetHouseWorkViewController: BaseViewController {
         label.alpha = 0
         return label
     }()
+    private let setTimeLabel: UILabel = {
+        let label = UILabel()
+        label.setTextWithLineHeight(text: "시간설정", lineHeight: 22)
+        label.textColor = .gray600
+        label.font = .title1
+        return label
+    }()
+    private let setTimeToggle: UISwitch = {
+        let toggle = UISwitch()
+        toggle.isOn = false
+        toggle.onTintColor = .blue
+        toggle.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
+        return toggle
+    }()
+    private let divider: UIView = {
+        let view = UIView()
+        view.backgroundColor = .gray100
+        return view
+    }()
+    private let setRepeatLabel: UILabel = {
+        let label = UILabel()
+        label.setTextWithLineHeight(text: "반복하기", lineHeight: 22)
+        label.textColor = .gray600
+        label.font = .title1
+        return label
+    }()
+    private let setRepeatToggle: UISwitch = {
+        let toggle = UISwitch()
+        toggle.isOn = false
+        toggle.onTintColor = .blue
+        toggle.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
+        return toggle
+    }()
     
     // MARK: - life cycle
     
@@ -85,6 +118,37 @@ final class SetHouseWorkViewController: BaseViewController {
             $0.bottom.equalTo(selectManagerView.snp.top).offset(-10)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.height.equalTo(36)
+        }
+        
+        view.addSubview(setTimeLabel)
+        setTimeLabel.snp.makeConstraints {
+            $0.top.equalTo(getManagerView.snp.bottom).offset(16)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+        }
+        
+        view.addSubview(setTimeToggle)
+        setTimeToggle.snp.makeConstraints {
+            $0.centerY.equalTo(setTimeLabel.snp.centerY)
+            $0.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+        }
+        
+        view.addSubview(divider)
+        divider.snp.makeConstraints {
+            $0.top.equalTo(setTimeLabel.snp.bottom).offset(16)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.height.equalTo(2)
+        }
+        
+        view.addSubview(setRepeatLabel)
+        setRepeatLabel.snp.makeConstraints {
+            $0.top.equalTo(divider.snp.bottom).offset(16)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+        }
+        
+        view.addSubview(setRepeatToggle)
+        setRepeatToggle.snp.makeConstraints {
+            $0.centerY.equalTo(setRepeatLabel.snp.centerY)
+            $0.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -288,13 +288,18 @@ final class SetHouseWorkViewController: BaseViewController {
                 }
                 self?.repeatCycleView.repeatCycleButton.isHidden = false
                 self?.repeatCycleView.repeatCycleLabel.isHidden = false
-                self?.repeatCycleCollectionView.snp.updateConstraints {
-                    $0.height.equalTo(40)
-                }
                 self?.repeatCycleDayLabel.isHidden = false
-                let selectedDays = HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatPattern?.joined(separator: ", ")
-                self?.repeatCycleDayLabel.text = "매주 " + (selectedDays ?? Date().dayOfWeekToKoreanString) + "요일에 반복해요"
-                self?.repeatCycleDayLabel.applyColor(to: (selectedDays ?? Date().dayOfWeekToKoreanString) + "요일", with: .positive20)
+                
+                if HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle == "매주" {
+                    self?.repeatCycleCollectionView.snp.updateConstraints {
+                        $0.height.equalTo(40)
+                    }
+                    let selectedDays = HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatPattern?.joined(separator: ", ")
+                    self?.repeatCycleDayLabel.text = "매주 " + (selectedDays ?? Date().dayOfWeekToKoreanString) + "요일에 반복해요"
+                    self?.repeatCycleDayLabel.applyColor(to: (selectedDays ?? Date().dayOfWeekToKoreanString) + "요일", with: .positive20)
+                } else {
+                    self?.updateToMonthToday()
+                }
             }
         }
     }
@@ -394,6 +399,7 @@ final class SetHouseWorkViewController: BaseViewController {
             }
             repeatCycleView.repeatCycleButton.isHidden = false
             repeatCycleView.repeatCycleLabel.isHidden = false
+            repeatCycleView.repeatCycleButtonLabel.text = "매주"
             repeatCycleCollectionView.snp.updateConstraints {
                 $0.height.equalTo(40)
             }
@@ -444,12 +450,14 @@ final class SetHouseWorkViewController: BaseViewController {
                 }
                 
                 self?.updateToMonthToday()
+                HouseWork.mockHouseWork[self?.selectedHouseWorkIndex ?? 0].repeatCycle = "매달"
             } else {
                 self?.repeatCycleCollectionView.snp.updateConstraints {
                     $0.height.equalTo(40)
                 }
                 
                 self?.updateToWeekToday()
+                HouseWork.mockHouseWork[self?.selectedHouseWorkIndex ?? 0].repeatCycle = "매주"
             }
             self?.repeatCycleView.repeatCycleButtonLabel.text = repeatCycle
             self?.repeatCycleMenu.isHidden = true
@@ -472,8 +480,8 @@ final class SetHouseWorkViewController: BaseViewController {
     }
     
     private func updateToMonthToday() {
-        repeatCycleDayLabel.text = "매달 " + Date().singleDayToKoreanString + "에 반복해요"
-        repeatCycleDayLabel.applyColor(to: Date().singleDayToKoreanString, with: .positive20)
+        repeatCycleDayLabel.text = "매달 " + Date().singleDayToKoreanString + "일에 반복해요"
+        repeatCycleDayLabel.applyColor(to: Date().singleDayToKoreanString + "일", with: .positive20)
     }
     
     private func isTimeSelected(_ houseWork: Int) {
@@ -509,16 +517,21 @@ final class SetHouseWorkViewController: BaseViewController {
             }
             repeatCycleView.repeatCycleButton.isHidden = false
             repeatCycleView.repeatCycleLabel.isHidden = false
-            repeatCycleCollectionView.snp.updateConstraints {
-                $0.height.equalTo(40)
-            }
             repeatCycleDayLabel.isHidden = false
-            let selectedDays = HouseWork.mockHouseWork[houseWork].repeatPattern?.joined(separator: ", ")
-            repeatCycleDayLabel.text = "매주 " + (selectedDays ?? Date().dayOfWeekToKoreanString) + "요일에 반복해요"
-            repeatCycleDayLabel.applyColor(to: (selectedDays ?? Date().dayOfWeekToKoreanString) + "요일", with: .positive20)
             
-            repeatCycleCollectionView.selectedHouseWorkIndex = houseWork
-            repeatCycleCollectionView.collectionView.reloadData()
+            if HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle == "매주" {
+                repeatCycleCollectionView.snp.updateConstraints {
+                    $0.height.equalTo(40)
+                }
+                
+                let selectedDays = HouseWork.mockHouseWork[houseWork].repeatPattern?.joined(separator: ", ")
+                repeatCycleDayLabel.text = "매주 " + (selectedDays ?? Date().dayOfWeekToKoreanString) + "요일에 반복해요"
+                repeatCycleDayLabel.applyColor(to: (selectedDays ?? Date().dayOfWeekToKoreanString) + "요일", with: .positive20)
+                repeatCycleCollectionView.selectedHouseWorkIndex = houseWork
+                repeatCycleCollectionView.collectionView.reloadData()
+            } else {
+                updateToMonthToday()
+            }
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -188,7 +188,7 @@ final class SetHouseWorkViewController: BaseViewController {
         }
         
         timePicker.snp.makeConstraints {
-            $0.top.equalTo(setTimeLabel.snp.bottom).offset(12)
+            $0.top.equalTo(setTimeLabel.snp.bottom)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.height.equalTo(0)
         }
@@ -202,12 +202,12 @@ final class SetHouseWorkViewController: BaseViewController {
         setRepeatLabel.snp.makeConstraints {
             $0.top.equalTo(divider.snp.bottom).offset(SizeLiteral.componentPadding)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
-            $0.bottom.equalTo(0)
         }
         
         setRepeatToggle.snp.makeConstraints {
             $0.centerY.equalTo(setRepeatLabel.snp.centerY)
             $0.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalTo(0)
         }
         
         repeatCycleView.snp.makeConstraints {
@@ -259,14 +259,6 @@ final class SetHouseWorkViewController: BaseViewController {
         navigationItem.leftBarButtonItem = backButton
     }
     
-    private func showSelectManagerView() {
-        selectManagerView.snp.updateConstraints {
-            $0.height.equalTo(341)
-        }
-        addAnimation()
-        selectManagerView.selectManagerCollectionView.selectedManagerList = getManagerView.getManagerCollectionView.selectedMemberList
-    }
-    
     private func didTappedHouseWork() {
         setHouseWorkCollectionView.didTappedHouseWork = { [weak self] selectedHouseWorkIndex in
             self?.selectedHouseWorkIndex = selectedHouseWorkIndex
@@ -287,16 +279,24 @@ final class SetHouseWorkViewController: BaseViewController {
                 self?.selectedHouseWorkIndex -= 1
                 self?.repeatCycleCollectionView.selectedHouseWorkIndex -= 1
                 self?.updateManagerTimeRepeat(deletedHouseWorkIndex - 1)
+            } else if deletedHouseWorkIndex == self?.selectedHouseWorkIndex {
+                self?.updateManagerTimeRepeat(deletedHouseWorkIndex)
             } else if deletedHouseWorkIndex < self?.selectedHouseWorkIndex ?? 0 {
                 self?.selectedHouseWorkIndex -= 1
                 self?.repeatCycleCollectionView.selectedHouseWorkIndex -= 1
                 self?.updateManagerTimeRepeat(self?.selectedHouseWorkIndex ?? 0)
-            } else if deletedHouseWorkIndex == self?.selectedHouseWorkIndex {
-                self?.updateManagerTimeRepeat(deletedHouseWorkIndex)
             } else {
                 self?.updateManagerTimeRepeat(self?.selectedHouseWorkIndex ?? 0)
             }
         }
+    }
+    
+    private func showSelectManagerView() {
+        selectManagerView.snp.updateConstraints {
+            $0.height.equalTo(341)
+        }
+        addAnimation()
+        selectManagerView.selectManagerCollectionView.selectedManagerList = getManagerView.getManagerCollectionView.selectedMemberList
     }
     
     private func didTappedCancelButton() {
@@ -335,11 +335,13 @@ final class SetHouseWorkViewController: BaseViewController {
     private func didTappedTimeToggle() {
         if setTimeToggle.isOn {
             timePicker.snp.updateConstraints {
+                $0.top.equalTo(setTimeLabel.snp.bottom).offset(8)
                 $0.height.equalTo(196.2)
             }
             addAnimation()
         } else {
             timePicker.snp.updateConstraints {
+                $0.top.equalTo(setTimeLabel.snp.bottom)
                 $0.height.equalTo(0)
             }
             HouseWork.mockHouseWork[selectedHouseWorkIndex].time = "하루 종일"
@@ -347,41 +349,49 @@ final class SetHouseWorkViewController: BaseViewController {
         }
     }
     
+    private func didTimeChanged() {
+        let time = timePicker.date.timeToKoreanString
+        HouseWork.mockHouseWork[selectedHouseWorkIndex].time = time
+        setHouseWorkCollectionView.collectionView.reloadData()
+    }
+    
     private func didTappedRepeatToggle() {
         if setRepeatToggle.isOn {
             openRepeatCycleView()
-            repeatCycleView.repeatCycleButtonLabel.text = RepeatType.week.rawValue
             repeatCycleCollectionView.snp.updateConstraints {
                 $0.height.equalTo(40)
+            }
+            setRepeatToggle.snp.remakeConstraints {
+                $0.centerY.equalTo(setRepeatLabel.snp.centerY)
+                $0.trailing.equalToSuperview().inset(20)
             }
             repeatCycleDayLabel.snp.remakeConstraints {
                 $0.top.equalTo(repeatCycleCollectionView.snp.bottom).offset(16)
                 $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
-                $0.height.equalTo(22)
                 $0.bottom.equalTo(0)
             }
-            setRepeatLabel.snp.remakeConstraints {
-                $0.top.equalTo(divider.snp.bottom).offset(SizeLiteral.componentPadding)
-                $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
-            }
+            HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle = RepeatType.week
+            repeatCycleView.repeatCycleButtonLabel.text = RepeatType.week.rawValue
             updateRepeatCycleDayLabel(.week, Date().dayOfWeekToKoreanString)
             repeatCycleCollectionView.selectedDaysOfWeek = []
-            HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle = RepeatType.week
         } else {
             closeRepeatCycleView()
             repeatCycleCollectionView.snp.updateConstraints {
                 $0.height.equalTo(0)
             }
+            setRepeatToggle.snp.remakeConstraints {
+                $0.centerY.equalTo(setRepeatLabel.snp.centerY)
+                $0.trailing.equalToSuperview().inset(20)
+                $0.bottom.equalTo(0)
+            }
+            repeatCycleDayLabel.snp.remakeConstraints {
+                $0.top.equalTo(repeatCycleCollectionView.snp.bottom).offset(16)
+                $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            }
             HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle = nil
             HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatPattern = nil
         }
         addAnimation()
-    }
-    
-    private func didTimeChanged() {
-        let time = timePicker.date.timeToKoreanString
-        HouseWork.mockHouseWork[selectedHouseWorkIndex].time = time
-        setHouseWorkCollectionView.collectionView.reloadData()
     }
     
     private func didTappedRepeatCycleButton() {
@@ -421,11 +431,13 @@ final class SetHouseWorkViewController: BaseViewController {
         if HouseWork.mockHouseWork[houseWork].time == "하루 종일" {
             setTimeToggle.isOn = false
             timePicker.snp.updateConstraints {
+                $0.top.equalTo(setTimeLabel.snp.bottom)
                 $0.height.equalTo(0)
             }
         } else {
             setTimeToggle.isOn = true
             timePicker.snp.updateConstraints {
+                $0.top.equalTo(setTimeLabel.snp.bottom).offset(8)
                 $0.height.equalTo(196.2)
             }
         }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -113,10 +113,8 @@ final class SetHouseWorkViewController: BaseViewController {
     private let repeatCycleCollectionView = RepeatCycleCollectionView()
     private lazy var repeatCycleDayLabel: UILabel = {
         let label = UILabel()
-        label.text = "매주 " + Date().dayOfWeekToKoreanString + "요일에 반복해요"
         label.textColor = .gray400
         label.font = .body2
-        label.applyColor(to: Date().dayOfWeekToKoreanString + "요일", with: .positive20)
         label.isHidden = true
         return label
     }()
@@ -381,7 +379,7 @@ final class SetHouseWorkViewController: BaseViewController {
     
     private func didSelectDaysOfWeek() {
         repeatCycleCollectionView.didSelectDaysOfWeek = { [weak self] selectedDays in
-            let selectedDaysOfWeek = selectedDays.joined(separator: ", ")
+            let selectedDaysOfWeek = selectedDays.isEmpty ? Date().dayOfWeekToKoreanString : selectedDays.joined(separator: ", ")
             self?.repeatCycleDayLabel.text = "매주 " + selectedDaysOfWeek + "요일에 반복해요"
             self?.repeatCycleDayLabel.applyColor(to: selectedDaysOfWeek + "요일", with: .positive20)
         }
@@ -389,7 +387,7 @@ final class SetHouseWorkViewController: BaseViewController {
     
     private func updateToWeekToday() {
         repeatCycleDayLabel.text = "매주 " + Date().dayOfWeekToKoreanString + "요일에 반복해요"
-        repeatCycleDayLabel.applyColor(to: Date().dayOfWeekToKoreanString, with: .positive20)
+        repeatCycleDayLabel.applyColor(to: Date().dayOfWeekToKoreanString + "요일", with: .positive20)
         repeatCycleCollectionView.selectedDaysOfWeek = []
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -267,26 +267,20 @@ final class SetHouseWorkViewController: BaseViewController {
                 $0.height.equalTo(0)
             }
             
-            if HouseWork.mockHouseWork[selectedHouseWorkIndex].time == "하루 종일" {
-                self?.setTimeToggle.isOn = false
-                self?.timePicker.snp.updateConstraints {
-                    $0.height.equalTo(0)
-                }
-            } else {
-                self?.setTimeToggle.isOn = true
-                self?.timePicker.snp.updateConstraints {
-                    $0.height.equalTo(196.2)
-                }
-            }
+            self?.isTimeSelected(selectedHouseWorkIndex)
         }
     }
     
     private func didDeleteHouseWork() {
         setHouseWorkCollectionView.didDeleteHouseWork = { [weak self] deletedHouseWorkIndex in
-            if deletedHouseWorkIndex == HouseWork.mockHouseWork.endIndex {
+            if HouseWork.mockHouseWork.count == 0 {
+                // FIXME: - 이전 페이지로 이동
+            } else if deletedHouseWorkIndex == HouseWork.mockHouseWork.endIndex {
                 self?.getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[deletedHouseWorkIndex - 1].manager
+                self?.isTimeSelected(deletedHouseWorkIndex - 1)
             } else {
                 self?.getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[deletedHouseWorkIndex].manager
+                self?.isTimeSelected(deletedHouseWorkIndex)
             }
         }
     }
@@ -432,5 +426,19 @@ final class SetHouseWorkViewController: BaseViewController {
     private func updateToMonthToday() {
         repeatCycleDayLabel.text = "매달 " + Date().singleDayToKoreanString + "에 반복해요"
         repeatCycleDayLabel.applyColor(to: Date().singleDayToKoreanString, with: .positive20)
+    }
+    
+    private func isTimeSelected(_ houseWork: Int) {
+        if HouseWork.mockHouseWork[houseWork].time == "하루 종일" {
+            setTimeToggle.isOn = false
+            timePicker.snp.updateConstraints {
+                $0.height.equalTo(0)
+            }
+        } else {
+            setTimeToggle.isOn = true
+            timePicker.snp.updateConstraints {
+                $0.height.equalTo(196.2)
+            }
+        }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -212,7 +212,7 @@ final class SetHouseWorkViewController: BaseViewController {
         
         repeatCycleView.snp.makeConstraints {
             $0.top.equalTo(setRepeatLabel.snp.bottom).offset(SizeLiteral.componentPadding)
-            $0.leading.trailing.equalToSuperview().inset(31.5)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.height.equalTo(0)
         }
         
@@ -224,7 +224,7 @@ final class SetHouseWorkViewController: BaseViewController {
         
         repeatCycleMenu.snp.makeConstraints {
             $0.top.equalTo(repeatCycleView.snp.bottom)
-            $0.trailing.equalToSuperview().inset(31.5)
+            $0.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.width.equalTo(98)
             $0.height.equalTo(76)
         }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -109,8 +109,14 @@ final class SetHouseWorkViewController: BaseViewController {
         view.repeatCycleButton.addAction(action, for: .touchUpInside)
         return view
     }()
+    private let repeatCycleMenu = RepeatCycleMenu()
     
     // MARK: - life cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        didTappedRepeatCycleMenuButton()
+    }
     
     override func render() {
         view.addSubview(setHouseWorkCalendarView)
@@ -191,6 +197,14 @@ final class SetHouseWorkViewController: BaseViewController {
             $0.top.equalTo(setRepeatLabel.snp.bottom).offset(SizeLiteral.componentPadding)
             $0.leading.trailing.equalToSuperview().inset(31.5)
             $0.height.equalTo(36)
+        }
+        
+        view.addSubview(repeatCycleMenu)
+        repeatCycleMenu.snp.makeConstraints {
+            $0.top.equalTo(repeatCycleView.snp.bottom)
+            $0.trailing.equalToSuperview().inset(31.5)
+            $0.width.equalTo(98)
+            $0.height.equalTo(76)
         }
     }
     
@@ -289,6 +303,14 @@ final class SetHouseWorkViewController: BaseViewController {
     }
     
     private func didTappedRepeatCycleButton() {
-        print("누름")
+        repeatCycleMenu.isHidden.toggle()
+    }
+    
+    private func didTappedRepeatCycleMenuButton() {
+        repeatCycleMenu.didTappedRepeatCycleMenuButton = { [weak self] repeatCycle in
+            self?.repeatCycleView.repeatCycleButtonLabel.text = repeatCycle
+            self?.repeatCycleMenu.isHidden = true
+        }
+        
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -11,6 +11,8 @@ import SnapKit
 
 final class SetHouseWorkViewController: BaseViewController {
     
+    var selectedDaysOfWeek = Date().dayOfWeekToKoreanString
+    
     // MARK: - property
     
     private let backButton = BackButton(type: .system)
@@ -111,6 +113,14 @@ final class SetHouseWorkViewController: BaseViewController {
     }()
     private let repeatCycleMenu = RepeatCycleMenu()
     private let repeatCycleCollectionView = RepeatCycleCollectionView()
+    private lazy var repeatCycleDayLabel: UILabel = {
+       let label = UILabel()
+        label.text = "매주 " + selectedDaysOfWeek + "요일에 반복해요"
+        label.textColor = .gray400
+        label.font = .body2
+        label.applyColor(to: selectedDaysOfWeek + "요일", with: .positive20)
+        return label
+    }()
     
     // MARK: - life cycle
     
@@ -202,7 +212,7 @@ final class SetHouseWorkViewController: BaseViewController {
         
         view.addSubview(repeatCycleCollectionView)
         repeatCycleCollectionView.snp.makeConstraints {
-            $0.top.equalTo(repeatCycleView.snp.bottom).offset(8)
+            $0.top.equalTo(repeatCycleView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(56)
         }
@@ -213,6 +223,12 @@ final class SetHouseWorkViewController: BaseViewController {
             $0.trailing.equalToSuperview().inset(31.5)
             $0.width.equalTo(98)
             $0.height.equalTo(76)
+        }
+        
+        view.addSubview(repeatCycleDayLabel)
+        repeatCycleDayLabel.snp.makeConstraints {
+            $0.top.equalTo(repeatCycleCollectionView.snp.bottom).offset(8)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -140,99 +140,88 @@ final class SetHouseWorkViewController: BaseViewController {
     }
     
     override func render() {
-        view.addSubview(setHouseWorkCalendarView)
+        view.addSubviews(setHouseWorkCalendarView, setHouseWorkCollectionView, doneButton, scrollView, selectManagerView, managerToastLabel)
+        scrollView.addSubview(contentView)
+        contentView.addSubviews(getManagerView, setTimeLabel, setTimeToggle, timePicker, divider, setRepeatLabel, setRepeatToggle, repeatCycleView, repeatCycleCollectionView, repeatCycleMenu, repeatCycleDayLabel)
+        
         setHouseWorkCalendarView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(38)
         }
         
-        view.addSubview(setHouseWorkCollectionView)
         setHouseWorkCollectionView.snp.makeConstraints {
             $0.top.equalTo(setHouseWorkCalendarView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(134)
         }
         
-        view.addSubview(doneButton)
         doneButton.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(SizeLiteral.componentPadding)
         }
         
-        view.addSubview(scrollView)
         scrollView.snp.makeConstraints {
             $0.top.equalTo(setHouseWorkCollectionView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(doneButton.snp.top).inset(-SizeLiteral.componentPadding)
         }
         
-        scrollView.addSubview(contentView)
         contentView.snp.makeConstraints {
             $0.width.edges.equalToSuperview()
         }
         
-        contentView.addSubview(getManagerView)
         getManagerView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(120)
         }
         
-        contentView.addSubview(setTimeLabel)
         setTimeLabel.snp.makeConstraints {
             $0.top.equalTo(getManagerView.snp.bottom).offset(SizeLiteral.componentPadding)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
-        contentView.addSubview(setTimeToggle)
         setTimeToggle.snp.makeConstraints {
             $0.centerY.equalTo(setTimeLabel.snp.centerY)
             $0.trailing.equalToSuperview().inset(20)
         }
         
-        contentView.addSubview(timePicker)
         timePicker.snp.makeConstraints {
             $0.top.equalTo(setTimeLabel.snp.bottom).offset(12)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.height.equalTo(0)
         }
         
-        contentView.addSubview(divider)
         divider.snp.makeConstraints {
             $0.top.equalTo(timePicker.snp.bottom).offset(SizeLiteral.componentPadding)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.height.equalTo(2)
         }
         
-        contentView.addSubview(setRepeatLabel)
         setRepeatLabel.snp.makeConstraints {
             $0.top.equalTo(divider.snp.bottom).offset(SizeLiteral.componentPadding)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.bottom.equalTo(0)
         }
         
-        contentView.addSubview(setRepeatToggle)
         setRepeatToggle.snp.makeConstraints {
             $0.centerY.equalTo(setRepeatLabel.snp.centerY)
             $0.trailing.equalToSuperview().inset(20)
         }
         
-        contentView.addSubview(repeatCycleView)
         repeatCycleView.snp.makeConstraints {
             $0.top.equalTo(setRepeatLabel.snp.bottom).offset(SizeLiteral.componentPadding)
             $0.leading.trailing.equalToSuperview().inset(31.5)
             $0.height.equalTo(0)
         }
         
-        contentView.addSubview(repeatCycleCollectionView)
         repeatCycleCollectionView.snp.makeConstraints {
             $0.top.equalTo(repeatCycleView.snp.bottom).offset(8)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(0)
         }
         
-        contentView.addSubview(repeatCycleMenu)
         repeatCycleMenu.snp.makeConstraints {
             $0.top.equalTo(repeatCycleView.snp.bottom)
             $0.trailing.equalToSuperview().inset(31.5)
@@ -240,20 +229,17 @@ final class SetHouseWorkViewController: BaseViewController {
             $0.height.equalTo(76)
         }
         
-        contentView.addSubview(repeatCycleDayLabel)
         repeatCycleDayLabel.snp.makeConstraints {
             $0.top.equalTo(repeatCycleCollectionView.snp.bottom).offset(16)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
-        view.addSubview(selectManagerView)
         selectManagerView.snp.makeConstraints {
             $0.bottom.equalToSuperview()
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(0)
         }
-
-        view.addSubview(managerToastLabel)
+        
         managerToastLabel.snp.makeConstraints {
             $0.bottom.equalTo(selectManagerView.snp.top).offset(-10)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -11,8 +11,6 @@ import SnapKit
 
 final class SetHouseWorkViewController: BaseViewController {
     
-    var selectedDaysOfWeek = Date().dayOfWeekToKoreanString
-    
     // MARK: - property
     
     private let backButton = BackButton(type: .system)
@@ -115,10 +113,10 @@ final class SetHouseWorkViewController: BaseViewController {
     private let repeatCycleCollectionView = RepeatCycleCollectionView()
     private lazy var repeatCycleDayLabel: UILabel = {
        let label = UILabel()
-        label.text = "매주 " + selectedDaysOfWeek + "요일에 반복해요"
+        label.text = "매주 " + Date().dayOfWeekToKoreanString + "요일에 반복해요"
         label.textColor = .gray400
         label.font = .body2
-        label.applyColor(to: selectedDaysOfWeek + "요일", with: .positive20)
+        label.applyColor(to: Date().dayOfWeekToKoreanString + "요일", with: .positive20)
         return label
     }()
     
@@ -127,6 +125,7 @@ final class SetHouseWorkViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         didTappedRepeatCycleMenuButton()
+        didSelectDaysOfWeek()
     }
     
     override func render() {
@@ -343,6 +342,14 @@ final class SetHouseWorkViewController: BaseViewController {
             }
             self?.repeatCycleView.repeatCycleButtonLabel.text = repeatCycle
             self?.repeatCycleMenu.isHidden = true
+        }
+    }
+    
+    private func didSelectDaysOfWeek() {
+        repeatCycleCollectionView.didSelectDaysOfWeek = { [weak self] selectedDays in
+            let selectedDaysOfWeek = selectedDays.joined(separator: ", ")
+            self?.repeatCycleDayLabel.text = "매주 " + selectedDaysOfWeek + "요일에 반복해요"
+            self?.repeatCycleDayLabel.applyColor(to: selectedDaysOfWeek + "요일", with: .positive20)
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -294,11 +294,9 @@ final class SetHouseWorkViewController: BaseViewController {
                     self?.repeatCycleCollectionView.snp.updateConstraints {
                         $0.height.equalTo(40)
                     }
-                    let selectedDays = HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatPattern?.joined(separator: ", ")
-                    self?.repeatCycleDayLabel.text = "매주 " + (selectedDays ?? Date().dayOfWeekToKoreanString) + "요일에 반복해요"
-                    self?.repeatCycleDayLabel.applyColor(to: (selectedDays ?? Date().dayOfWeekToKoreanString) + "요일", with: .positive20)
+                    self?.updateRepeatCycleDayLabel(.week, HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatPattern?.joined(separator: ", ") ?? Date().dayOfWeekToKoreanString)
                 } else {
-                    self?.updateToMonthToday()
+                    self?.updateRepeatCycleDayLabel(.month, Date().singleDayToKoreanString)
                 }
             }
         }
@@ -392,7 +390,8 @@ final class SetHouseWorkViewController: BaseViewController {
                 $0.top.equalTo(divider.snp.bottom).offset(SizeLiteral.componentPadding)
                 $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             }
-            updateToWeekToday()
+            updateRepeatCycleDayLabel(.week, Date().dayOfWeekToKoreanString)
+            repeatCycleCollectionView.selectedDaysOfWeek = []
             HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle = RepeatType.week
             
             // FIXME: - Calendar View 비활성화 (개발되면 변경)
@@ -427,14 +426,15 @@ final class SetHouseWorkViewController: BaseViewController {
                     $0.height.equalTo(0)
                 }
                 
-                self?.updateToMonthToday()
+                self?.updateRepeatCycleDayLabel(.month, Date().singleDayToKoreanString)
                 HouseWork.mockHouseWork[self?.selectedHouseWorkIndex ?? 0].repeatCycle = repeatCycle
             } else {
                 self?.repeatCycleCollectionView.snp.updateConstraints {
                     $0.height.equalTo(40)
                 }
                 
-                self?.updateToWeekToday()
+                self?.updateRepeatCycleDayLabel(.week, Date().dayOfWeekToKoreanString)
+                self?.repeatCycleCollectionView.selectedDaysOfWeek = []
                 HouseWork.mockHouseWork[self?.selectedHouseWorkIndex ?? 0].repeatCycle = repeatCycle
             }
             self?.repeatCycleView.repeatCycleButtonLabel.text = repeatCycle.rawValue
@@ -445,21 +445,9 @@ final class SetHouseWorkViewController: BaseViewController {
     private func didSelectDaysOfWeek() {
         repeatCycleCollectionView.didSelectDaysOfWeek = { [weak self] selectedDays in
             let selectedDaysOfWeek = selectedDays.isEmpty ? Date().dayOfWeekToKoreanString : selectedDays.joined(separator: ", ")
-            self?.repeatCycleDayLabel.text = "매주 " + selectedDaysOfWeek + "요일에 반복해요"
-            self?.repeatCycleDayLabel.applyColor(to: selectedDaysOfWeek + "요일", with: .positive20)
+            self?.updateRepeatCycleDayLabel(.week, selectedDaysOfWeek)
             HouseWork.mockHouseWork[self?.selectedHouseWorkIndex ?? 0].repeatPattern = selectedDays
         }
-    }
-    
-    private func updateToWeekToday() {
-        repeatCycleDayLabel.text = "매주 " + Date().dayOfWeekToKoreanString + "요일에 반복해요"
-        repeatCycleDayLabel.applyColor(to: Date().dayOfWeekToKoreanString + "요일", with: .positive20)
-        repeatCycleCollectionView.selectedDaysOfWeek = []
-    }
-    
-    private func updateToMonthToday() {
-        repeatCycleDayLabel.text = "매달 " + Date().singleDayToKoreanString + "일에 반복해요"
-        repeatCycleDayLabel.applyColor(to: Date().singleDayToKoreanString + "일", with: .positive20)
     }
     
     private func isTimeSelected(_ houseWork: Int) {
@@ -492,13 +480,11 @@ final class SetHouseWorkViewController: BaseViewController {
                     $0.height.equalTo(40)
                 }
                 
-                let selectedDays = HouseWork.mockHouseWork[houseWork].repeatPattern?.joined(separator: ", ")
-                repeatCycleDayLabel.text = "매주 " + (selectedDays ?? Date().dayOfWeekToKoreanString) + "요일에 반복해요"
-                repeatCycleDayLabel.applyColor(to: (selectedDays ?? Date().dayOfWeekToKoreanString) + "요일", with: .positive20)
+                updateRepeatCycleDayLabel(.week, HouseWork.mockHouseWork[houseWork].repeatPattern?.joined(separator: ", ") ?? Date().dayOfWeekToKoreanString)
                 repeatCycleCollectionView.selectedHouseWorkIndex = houseWork
                 repeatCycleCollectionView.collectionView.reloadData()
             } else {
-                updateToMonthToday()
+                updateRepeatCycleDayLabel(.month, Date().singleDayToKoreanString)
             }
         }
     }
@@ -531,5 +517,16 @@ final class SetHouseWorkViewController: BaseViewController {
         repeatCycleView.repeatCycleLabel.isHidden = true
         repeatCycleView.repeatCycleButton.isHidden = true
         repeatCycleDayLabel.isHidden = true
+    }
+    
+    private func updateRepeatCycleDayLabel(_ type: RepeatType, _ repeatDay: String) {
+        switch type {
+        case .week:
+            repeatCycleDayLabel.text = "매주 " + repeatDay + "요일에 반복해요"
+            repeatCycleDayLabel.applyColor(to: repeatDay + "요일", with: .positive20)
+        case .month:
+            repeatCycleDayLabel.text = "매달 " + repeatDay + "일에 반복해요"
+            repeatCycleDayLabel.applyColor(to: repeatDay + "일", with: .positive20)
+        }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -391,6 +391,7 @@ final class SetHouseWorkViewController: BaseViewController {
             }
             HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle = nil
             HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatPattern = nil
+            repeatCycleMenu.isHidden = true
         }
         addAnimation()
     }
@@ -422,9 +423,13 @@ final class SetHouseWorkViewController: BaseViewController {
     
     private func didSelectDaysOfWeek() {
         repeatCycleCollectionView.didSelectDaysOfWeek = { [weak self] selectedDays in
-            let selectedDaysOfWeek = selectedDays.isEmpty ? Date().dayOfWeekToKoreanString : selectedDays.joined(separator: ", ")
+            var sortedDays: [String] = []
+            for day in selectedDays.sorted(){
+                sortedDays.append(String(day.dropFirst(1)))
+            }
+            let selectedDaysOfWeek = selectedDays.isEmpty ? Date().dayOfWeekToKoreanString : sortedDays.joined(separator: ", ")
             self?.updateRepeatCycleDayLabel(.week, selectedDaysOfWeek)
-            HouseWork.mockHouseWork[self?.selectedHouseWorkIndex ?? 0].repeatPattern = selectedDays
+            HouseWork.mockHouseWork[self?.selectedHouseWorkIndex ?? 0].repeatPattern = sortedDays
         }
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -75,7 +75,7 @@ final class SetHouseWorkViewController: BaseViewController {
         picker.locale = Locale(identifier: "ko-KR")
         picker.timeZone = .autoupdatingCurrent
         let action = UIAction { [weak self] _ in
-            self?.didChangedTime()
+            self?.didTimeChanged()
         }
         picker.addAction(action, for: .valueChanged)
         return picker
@@ -126,6 +126,7 @@ final class SetHouseWorkViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         didTappedHouseWork()
+        didDeleteHouseWork()
         didTappedRepeatCycleMenuButton()
         didSelectDaysOfWeek()
     }
@@ -268,6 +269,16 @@ final class SetHouseWorkViewController: BaseViewController {
         }
     }
     
+    private func didDeleteHouseWork() {
+        setHouseWorkCollectionView.didDeleteHouseWork = { [weak self] deletedHouseWorkIndex in
+            if deletedHouseWorkIndex == HouseWork.mockHouseWork.endIndex {
+                self?.getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[deletedHouseWorkIndex - 1].manager
+            } else {
+                self?.getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[deletedHouseWorkIndex].manager
+            }
+        }
+    }
+    
     private func didTappedCancelButton() {
         selectManagerView.snp.updateConstraints {
             $0.height.equalTo(0)
@@ -359,13 +370,13 @@ final class SetHouseWorkViewController: BaseViewController {
         }
     }
     
-    private func didChangedTime() {
+    private func didTimeChanged() {
         let dateformatter = DateFormatter()
         dateformatter.dateStyle = .none
         dateformatter.timeStyle = .short
-        let date = timePicker.date.timeToKoreanString
-        // FIXME: - 모델 생성 후 CollectionView에 시간 반영
-        print(date)
+        let time = timePicker.date.timeToKoreanString
+        HouseWork.mockHouseWork[selectedHouseWorkIndex].time = time
+        setHouseWorkCollectionView.collectionView.reloadData()
     }
     
     private func didTappedRepeatCycleButton() {

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -301,20 +301,20 @@ final class SetHouseWorkViewController: BaseViewController {
     
     private func didDeleteHouseWork() {
         setHouseWorkCollectionView.didDeleteHouseWork = { [weak self] deletedHouseWorkIndex in
-            print(self?.selectedHouseWorkIndex)
-            print(deletedHouseWorkIndex)
             if HouseWork.mockHouseWork.count == 0 {
                 // FIXME: - 이전 페이지로 이동
             } else if deletedHouseWorkIndex == HouseWork.mockHouseWork.endIndex && deletedHouseWorkIndex == self?.selectedHouseWorkIndex ?? 0 {
+                self?.selectedHouseWorkIndex -= 1
+                self?.repeatCycleCollectionView.selectedHouseWorkIndex -= 1
                 self?.getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[deletedHouseWorkIndex - 1].manager
                 self?.isTimeSelected(deletedHouseWorkIndex - 1)
                 self?.isRepeatSelected(deletedHouseWorkIndex - 1)
-                self?.selectedHouseWorkIndex -= 1
             } else if deletedHouseWorkIndex < self?.selectedHouseWorkIndex ?? 0 {
-                self?.getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[(self?.selectedHouseWorkIndex ?? 0) - 1].manager
-                self?.isTimeSelected((self?.selectedHouseWorkIndex ?? 0) - 1)
-                self?.isRepeatSelected((self?.selectedHouseWorkIndex ?? 0) - 1)
                 self?.selectedHouseWorkIndex -= 1
+                self?.repeatCycleCollectionView.selectedHouseWorkIndex -= 1
+                self?.getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[self?.selectedHouseWorkIndex ?? 0].manager
+                self?.isTimeSelected(self?.selectedHouseWorkIndex ?? 0)
+                self?.isRepeatSelected(self?.selectedHouseWorkIndex ?? 0)
             } else if deletedHouseWorkIndex == self?.selectedHouseWorkIndex {
                 self?.getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[deletedHouseWorkIndex].manager
                 self?.isTimeSelected(deletedHouseWorkIndex)
@@ -519,7 +519,6 @@ final class SetHouseWorkViewController: BaseViewController {
             
             repeatCycleCollectionView.selectedHouseWorkIndex = houseWork
             repeatCycleCollectionView.collectionView.reloadData()
-            print(selectedHouseWorkIndex)
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -324,9 +324,7 @@ final class SetHouseWorkViewController: BaseViewController {
                 $0.height.equalTo(40)
             }
             repeatCycleDayLabel.isHidden = false
-            repeatCycleDayLabel.text = "매주 " + Date().dayOfWeekToKoreanString + "요일에 반복해요"
-            repeatCycleDayLabel.applyColor(to: Date().dayOfWeekToKoreanString, with: .positive20)
-            repeatCycleCollectionView.selectedDaysOfWeek = []
+            updateToWeekToday()
             
             UIView.animate(withDuration: 0.3, delay: 0, options: .allowAnimatedContent, animations: {
                 self.view.layoutIfNeeded()
@@ -368,16 +366,13 @@ final class SetHouseWorkViewController: BaseViewController {
                     $0.height.equalTo(0)
                 }
                 
-                self?.repeatCycleDayLabel.text = "매달 " + Date().singleDayToKoreanString + "에 반복해요"
-                self?.repeatCycleDayLabel.applyColor(to: Date().singleDayToKoreanString, with: .positive20)
+                self?.updateToMonthToday()
             } else {
                 self?.repeatCycleCollectionView.snp.updateConstraints {
                     $0.height.equalTo(40)
                 }
                 
-                self?.repeatCycleDayLabel.text = "매주 " + Date().dayOfWeekToKoreanString + "요일에 반복해요"
-                self?.repeatCycleDayLabel.applyColor(to: Date().dayOfWeekToKoreanString, with: .positive20)
-                self?.repeatCycleCollectionView.selectedDaysOfWeek = []
+                self?.updateToWeekToday()
             }
             self?.repeatCycleView.repeatCycleButtonLabel.text = repeatCycle
             self?.repeatCycleMenu.isHidden = true
@@ -390,5 +385,16 @@ final class SetHouseWorkViewController: BaseViewController {
             self?.repeatCycleDayLabel.text = "매주 " + selectedDaysOfWeek + "요일에 반복해요"
             self?.repeatCycleDayLabel.applyColor(to: selectedDaysOfWeek + "요일", with: .positive20)
         }
+    }
+    
+    private func updateToWeekToday() {
+        repeatCycleDayLabel.text = "매주 " + Date().dayOfWeekToKoreanString + "요일에 반복해요"
+        repeatCycleDayLabel.applyColor(to: Date().dayOfWeekToKoreanString, with: .positive20)
+        repeatCycleCollectionView.selectedDaysOfWeek = []
+    }
+    
+    private func updateToMonthToday() {
+        repeatCycleDayLabel.text = "매달 " + Date().singleDayToKoreanString + "에 반복해요"
+        repeatCycleDayLabel.applyColor(to: Date().singleDayToKoreanString, with: .positive20)
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -54,7 +54,7 @@ final class SetHouseWorkViewController: BaseViewController {
     }()
     private let setTimeLabel: UILabel = {
         let label = UILabel()
-        label.setTextWithLineHeight(text: "시간설정", lineHeight: 22)
+        label.setTextWithLineHeight(text: TextLiteral.setHouseWorkViewControllerSetTimeLabel, lineHeight: 22)
         label.textColor = .gray600
         label.font = .title1
         return label
@@ -89,7 +89,7 @@ final class SetHouseWorkViewController: BaseViewController {
     }()
     private let setRepeatLabel: UILabel = {
         let label = UILabel()
-        label.setTextWithLineHeight(text: "반복하기", lineHeight: 22)
+        label.setTextWithLineHeight(text: TextLiteral.setHouseWorkViewControllerSetRepeatLabel, lineHeight: 22)
         label.textColor = .gray600
         label.font = .title1
         return label
@@ -124,7 +124,7 @@ final class SetHouseWorkViewController: BaseViewController {
     }()
     private let doneButton: MainButton = {
         let button = MainButton()
-        button.title = "집안일 추가 완료"
+        button.title = TextLiteral.setHouseWorkViewControllerDoneButtonText
         button.isDisabled = false
         return button
     }()
@@ -344,7 +344,7 @@ final class SetHouseWorkViewController: BaseViewController {
                 $0.top.equalTo(setTimeLabel.snp.bottom)
                 $0.height.equalTo(0)
             }
-            HouseWork.mockHouseWork[selectedHouseWorkIndex].time = "하루 종일"
+            HouseWork.mockHouseWork[selectedHouseWorkIndex].time = TextLiteral.setHouseWorkCollectionViewCellDefaultTimeLabel
             setHouseWorkCollectionView.collectionView.reloadData()
         }
     }
@@ -428,7 +428,7 @@ final class SetHouseWorkViewController: BaseViewController {
     }
     
     private func isTimeSelected(_ houseWork: Int) {
-        if HouseWork.mockHouseWork[houseWork].time == "하루 종일" {
+        if HouseWork.mockHouseWork[houseWork].time == TextLiteral.setHouseWorkCollectionViewCellDefaultTimeLabel {
             setTimeToggle.isOn = false
             timePicker.snp.updateConstraints {
                 $0.top.equalTo(setTimeLabel.snp.bottom)
@@ -448,6 +448,7 @@ final class SetHouseWorkViewController: BaseViewController {
         case .week:
             setRepeatToggle.isOn = true
             openRepeatCycleView()
+            repeatCycleView.repeatCycleButtonLabel.text = RepeatType.week.rawValue
             repeatCycleCollectionView.snp.updateConstraints {
                 $0.height.equalTo(40)
             }
@@ -457,6 +458,7 @@ final class SetHouseWorkViewController: BaseViewController {
         case .month:
             setRepeatToggle.isOn = true
             openRepeatCycleView()
+            repeatCycleView.repeatCycleButtonLabel.text = RepeatType.month.rawValue
             updateRepeatCycleDayLabel(.month, Date().singleDayToKoreanString)
         case .none:
             setRepeatToggle.isOn = false
@@ -500,11 +502,11 @@ final class SetHouseWorkViewController: BaseViewController {
     private func updateRepeatCycleDayLabel(_ type: RepeatType, _ repeatDay: String) {
         switch type {
         case .week:
-            repeatCycleDayLabel.text = "매주 " + repeatDay + "요일에 반복해요"
-            repeatCycleDayLabel.applyColor(to: repeatDay + "요일", with: .positive20)
+            repeatCycleDayLabel.text = TextLiteral.setHouseWorkViewControllerEveryWeek + repeatDay + TextLiteral.setHouseWorkViewControllerWeek + TextLiteral.setHouseWorkViewControllerRepeat
+            repeatCycleDayLabel.applyColor(to: repeatDay + TextLiteral.setHouseWorkViewControllerWeek, with: .positive20)
         case .month:
-            repeatCycleDayLabel.text = "매달 " + repeatDay + "일에 반복해요"
-            repeatCycleDayLabel.applyColor(to: repeatDay + "일", with: .positive20)
+            repeatCycleDayLabel.text = TextLiteral.setHouseWorkViewControllerEveryMonth + repeatDay + TextLiteral.setHouseWorkViewControllerDay + TextLiteral.setHouseWorkViewControllerRepeat
+            repeatCycleDayLabel.applyColor(to: repeatDay + TextLiteral.setHouseWorkViewControllerDay, with: .positive20)
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -200,19 +200,19 @@ final class SetHouseWorkViewController: BaseViewController {
             $0.height.equalTo(36)
         }
         
+        view.addSubview(repeatCycleCollectionView)
+        repeatCycleCollectionView.snp.makeConstraints {
+            $0.top.equalTo(repeatCycleView.snp.bottom).offset(8)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(56)
+        }
+        
         view.addSubview(repeatCycleMenu)
         repeatCycleMenu.snp.makeConstraints {
             $0.top.equalTo(repeatCycleView.snp.bottom)
             $0.trailing.equalToSuperview().inset(31.5)
             $0.width.equalTo(98)
             $0.height.equalTo(76)
-        }
-        
-        view.addSubview(repeatCycleCollectionView)
-        repeatCycleCollectionView.snp.makeConstraints {
-            $0.top.equalTo(repeatCycleView.snp.bottom)
-            $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(56)
         }
     }
     
@@ -316,6 +316,15 @@ final class SetHouseWorkViewController: BaseViewController {
     
     private func didTappedRepeatCycleMenuButton() {
         repeatCycleMenu.didTappedRepeatCycleMenuButton = { [weak self] repeatCycle in
+            if repeatCycle == "매달" {
+                self?.repeatCycleCollectionView.snp.updateConstraints {
+                    $0.height.equalTo(0)
+                }
+            } else {
+                self?.repeatCycleCollectionView.snp.updateConstraints {
+                    $0.height.equalTo(56)
+                }
+            }
             self?.repeatCycleView.repeatCycleButtonLabel.text = repeatCycle
             self?.repeatCycleMenu.isHidden = true
         }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -282,23 +282,13 @@ final class SetHouseWorkViewController: BaseViewController {
             self?.repeatCycleCollectionView.collectionView.reloadData()
             if HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle == nil {
                 self?.setRepeatToggle.isOn = false
-                self?.repeatCycleView.snp.updateConstraints {
-                    $0.height.equalTo(0)
-                }
-                self?.repeatCycleView.repeatCycleButton.isHidden = true
-                self?.repeatCycleView.repeatCycleLabel.isHidden = true
+                self?.closeRepeatCycleView()
                 self?.repeatCycleCollectionView.snp.updateConstraints {
                     $0.height.equalTo(0)
                 }
-                self?.repeatCycleDayLabel.isHidden = true
             } else {
                 self?.setRepeatToggle.isOn = true
-                self?.repeatCycleView.snp.updateConstraints {
-                    $0.height.equalTo(36)
-                }
-                self?.repeatCycleView.repeatCycleButton.isHidden = false
-                self?.repeatCycleView.repeatCycleLabel.isHidden = false
-                self?.repeatCycleDayLabel.isHidden = false
+                self?.openRepeatCycleView()
                 
                 if HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle == RepeatType.week {
                     self?.repeatCycleCollectionView.snp.updateConstraints {
@@ -387,16 +377,11 @@ final class SetHouseWorkViewController: BaseViewController {
     
     private func didTappedRepeatToggle() {
         if setRepeatToggle.isOn {
-            repeatCycleView.snp.updateConstraints {
-                $0.height.equalTo(36)
-            }
-            repeatCycleView.repeatCycleButton.isHidden = false
-            repeatCycleView.repeatCycleLabel.isHidden = false
+            openRepeatCycleView()
             repeatCycleView.repeatCycleButtonLabel.text = "매주"
             repeatCycleCollectionView.snp.updateConstraints {
                 $0.height.equalTo(40)
             }
-            repeatCycleDayLabel.isHidden = false
             repeatCycleDayLabel.snp.remakeConstraints {
                 $0.top.equalTo(repeatCycleCollectionView.snp.bottom).offset(16)
                 $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
@@ -412,15 +397,10 @@ final class SetHouseWorkViewController: BaseViewController {
             
             // FIXME: - Calendar View 비활성화 (개발되면 변경)
         } else {
-            repeatCycleView.snp.updateConstraints {
-                $0.height.equalTo(0)
-            }
-            repeatCycleView.repeatCycleButton.isHidden = true
-            repeatCycleView.repeatCycleLabel.isHidden = true
+            closeRepeatCycleView()
             repeatCycleCollectionView.snp.updateConstraints {
                 $0.height.equalTo(0)
             }
-            repeatCycleDayLabel.isHidden = true
             HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle = nil
             HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatPattern = nil
         }
@@ -499,23 +479,13 @@ final class SetHouseWorkViewController: BaseViewController {
     private func isRepeatSelected(_ houseWork: Int) {
         if HouseWork.mockHouseWork[houseWork].repeatCycle == nil {
             setRepeatToggle.isOn = false
-            repeatCycleView.snp.updateConstraints {
-                $0.height.equalTo(0)
-            }
-            repeatCycleView.repeatCycleButton.isHidden = true
-            repeatCycleView.repeatCycleLabel.isHidden = true
+            closeRepeatCycleView()
             repeatCycleCollectionView.snp.updateConstraints {
                 $0.height.equalTo(0)
             }
-            repeatCycleDayLabel.isHidden = true
         } else {
             setRepeatToggle.isOn = true
-            repeatCycleView.snp.updateConstraints {
-                $0.height.equalTo(36)
-            }
-            repeatCycleView.repeatCycleButton.isHidden = false
-            repeatCycleView.repeatCycleLabel.isHidden = false
-            repeatCycleDayLabel.isHidden = false
+            openRepeatCycleView()
             
             if HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle == RepeatType.week {
                 repeatCycleCollectionView.snp.updateConstraints {
@@ -543,5 +513,23 @@ final class SetHouseWorkViewController: BaseViewController {
         UIView.animate(withDuration: 0.4, delay: 0, options: .transitionCurlUp, animations: {
             self.view.layoutIfNeeded()
         }, completion: nil)
+    }
+    
+    private func openRepeatCycleView() {
+        repeatCycleView.snp.updateConstraints {
+            $0.height.equalTo(36)
+        }
+        repeatCycleView.repeatCycleLabel.isHidden = false
+        repeatCycleView.repeatCycleButton.isHidden = false
+        repeatCycleDayLabel.isHidden = false
+    }
+    
+    private func closeRepeatCycleView() {
+        repeatCycleView.snp.updateConstraints {
+            $0.height.equalTo(0)
+        }
+        repeatCycleView.repeatCycleLabel.isHidden = true
+        repeatCycleView.repeatCycleButton.isHidden = true
+        repeatCycleDayLabel.isHidden = true
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -11,6 +11,8 @@ import SnapKit
 
 final class SetHouseWorkViewController: BaseViewController {
     
+    private var selectedHouseWorkIndex: Int = 0
+    
     // MARK: - property
     
     private let backButton = BackButton(type: .system)
@@ -123,6 +125,7 @@ final class SetHouseWorkViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        didTappedHouseWork()
         didTappedRepeatCycleMenuButton()
         didSelectDaysOfWeek()
     }
@@ -254,6 +257,17 @@ final class SetHouseWorkViewController: BaseViewController {
         selectManagerView.selectManagerCollectionView.selectedManagerList = getManagerView.getManagerCollectionView.selectedMemberList
     }
     
+    private func didTappedHouseWork() {
+        setHouseWorkCollectionView.didTappedHouseWork = { [weak self] selectedHouseWorkIndex in
+            self?.selectedHouseWorkIndex = selectedHouseWorkIndex
+            self?.getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[selectedHouseWorkIndex].manager
+            
+            self?.selectManagerView.snp.updateConstraints {
+                $0.height.equalTo(0)
+            }
+        }
+    }
+    
     private func didTappedCancelButton() {
         selectManagerView.snp.updateConstraints {
             $0.height.equalTo(0)
@@ -277,6 +291,7 @@ final class SetHouseWorkViewController: BaseViewController {
             }, completion: nil)
             
             getManagerView.getManagerCollectionView.selectedMemberList = selectManagerView.selectManagerCollectionView.selectedManagerList
+            HouseWork.mockHouseWork[selectedHouseWorkIndex].manager = selectManagerView.selectManagerCollectionView.selectedManagerList
         } else {
             showToast()
         }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -150,20 +150,6 @@ final class SetHouseWorkViewController: BaseViewController {
             $0.height.equalTo(120)
         }
         
-        view.addSubview(selectManagerView)
-        selectManagerView.snp.makeConstraints {
-            $0.bottom.equalToSuperview()
-            $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(0)
-        }
-        
-        view.addSubview(managerToastLabel)
-        managerToastLabel.snp.makeConstraints {
-            $0.bottom.equalTo(selectManagerView.snp.top).offset(-10)
-            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
-            $0.height.equalTo(36)
-        }
-        
         view.addSubview(setTimeLabel)
         setTimeLabel.snp.makeConstraints {
             $0.top.equalTo(getManagerView.snp.bottom).offset(SizeLiteral.componentPadding)
@@ -228,6 +214,20 @@ final class SetHouseWorkViewController: BaseViewController {
         repeatCycleDayLabel.snp.makeConstraints {
             $0.top.equalTo(repeatCycleCollectionView.snp.bottom).offset(16)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+        }
+        
+        view.addSubview(selectManagerView)
+        selectManagerView.snp.makeConstraints {
+            $0.bottom.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(0)
+        }
+        
+        view.addSubview(managerToastLabel)
+        managerToastLabel.snp.makeConstraints {
+            $0.bottom.equalTo(selectManagerView.snp.top).offset(-10)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.height.equalTo(36)
         }
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -55,12 +55,24 @@ final class SetHouseWorkViewController: BaseViewController {
         label.font = .title1
         return label
     }()
-    private let setTimeToggle: UISwitch = {
+    private lazy var setTimeToggle: UISwitch = {
         let toggle = UISwitch()
         toggle.isOn = false
         toggle.onTintColor = .blue
         toggle.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
+        let action = UIAction { [weak self] _ in
+            self?.didTappedTimeToggle()
+        }
+        toggle.addAction(action, for: .touchUpInside)
         return toggle
+    }()
+    private let timePicker: UIDatePicker = {
+        let picker = UIDatePicker()
+        picker.preferredDatePickerStyle = .wheels
+        picker.datePickerMode = .time
+        picker.locale = Locale(identifier: "ko-KR")
+        picker.timeZone = .autoupdatingCurrent
+        return picker
     }()
     private let divider: UIView = {
         let view = UIView()
@@ -74,11 +86,15 @@ final class SetHouseWorkViewController: BaseViewController {
         label.font = .title1
         return label
     }()
-    private let setRepeatToggle: UISwitch = {
+    private lazy var setRepeatToggle: UISwitch = {
         let toggle = UISwitch()
         toggle.isOn = false
         toggle.onTintColor = .blue
         toggle.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
+        let action = UIAction { [weak self] _ in
+            self?.didTappedRepeatToggle()
+        }
+        toggle.addAction(action, for: .touchUpInside)
         return toggle
     }()
     
@@ -132,9 +148,16 @@ final class SetHouseWorkViewController: BaseViewController {
             $0.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
+        view.addSubview(timePicker)
+        timePicker.snp.makeConstraints {
+            $0.top.equalTo(setTimeLabel.snp.bottom).offset(12)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.height.equalTo(0)
+        }
+        
         view.addSubview(divider)
         divider.snp.makeConstraints {
-            $0.top.equalTo(setTimeLabel.snp.bottom).offset(16)
+            $0.top.equalTo(timePicker.snp.bottom).offset(16)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.height.equalTo(2)
         }
@@ -214,5 +237,26 @@ final class SetHouseWorkViewController: BaseViewController {
                 self.managerToastLabel.removeFromSuperview()
             })
         })
+    }
+    
+    private func didTappedTimeToggle() {
+        if setTimeToggle.isOn {
+            timePicker.snp.updateConstraints {
+                $0.height.equalTo(196.2)
+            }
+            
+            UIView.animate(withDuration: 0.3, delay: 0, options: .allowAnimatedContent, animations: {
+                self.view.layoutIfNeeded()
+            }, completion: nil)
+        } else {
+            timePicker.snp.updateConstraints {
+                $0.height.equalTo(0)
+            }
+        }
+        
+    }
+    
+    private func didTappedRepeatToggle() {
+        
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -110,6 +110,7 @@ final class SetHouseWorkViewController: BaseViewController {
         return view
     }()
     private let repeatCycleMenu = RepeatCycleMenu()
+    private let repeatCycleCollectionView = RepeatCycleCollectionView()
     
     // MARK: - life cycle
     
@@ -163,7 +164,7 @@ final class SetHouseWorkViewController: BaseViewController {
         view.addSubview(setTimeToggle)
         setTimeToggle.snp.makeConstraints {
             $0.centerY.equalTo(setTimeLabel.snp.centerY)
-            $0.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.trailing.equalToSuperview().inset(20)
         }
         
         view.addSubview(timePicker)
@@ -189,7 +190,7 @@ final class SetHouseWorkViewController: BaseViewController {
         view.addSubview(setRepeatToggle)
         setRepeatToggle.snp.makeConstraints {
             $0.centerY.equalTo(setRepeatLabel.snp.centerY)
-            $0.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.trailing.equalToSuperview().inset(20)
         }
         
         view.addSubview(repeatCycleView)
@@ -205,6 +206,13 @@ final class SetHouseWorkViewController: BaseViewController {
             $0.trailing.equalToSuperview().inset(31.5)
             $0.width.equalTo(98)
             $0.height.equalTo(76)
+        }
+        
+        view.addSubview(repeatCycleCollectionView)
+        repeatCycleCollectionView.snp.makeConstraints {
+            $0.top.equalTo(repeatCycleView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(56)
         }
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -311,6 +311,5 @@ final class SetHouseWorkViewController: BaseViewController {
             self?.repeatCycleView.repeatCycleButtonLabel.text = repeatCycle
             self?.repeatCycleMenu.isHidden = true
         }
-        
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -263,10 +263,7 @@ final class SetHouseWorkViewController: BaseViewController {
         selectManagerView.snp.updateConstraints {
             $0.height.equalTo(341)
         }
-        
-        UIView.animate(withDuration: 0.4, delay: 0, options: .transitionCurlUp, animations: {
-            self.view.layoutIfNeeded()
-        }, completion: nil)
+        addAnimation()
         
         selectManagerView.selectManagerCollectionView.selectedManagerList = getManagerView.getManagerCollectionView.selectedMemberList
     }
@@ -341,10 +338,7 @@ final class SetHouseWorkViewController: BaseViewController {
         selectManagerView.snp.updateConstraints {
             $0.height.equalTo(0)
         }
-        
-        UIView.animate(withDuration: 0.4, delay: 0, options: .transitionCurlDown, animations: {
-            self.view.layoutIfNeeded()
-        }, completion: nil)
+        addAnimation()
         
         selectManagerView.selectManagerCollectionView.selectedManagerList = getManagerView.getManagerCollectionView.selectedMemberList
     }
@@ -354,10 +348,7 @@ final class SetHouseWorkViewController: BaseViewController {
             selectManagerView.snp.updateConstraints {
                 $0.height.equalTo(0)
             }
-            
-            UIView.animate(withDuration: 0.4, delay: 0, options: .transitionCurlDown, animations: {
-                self.view.layoutIfNeeded()
-            }, completion: nil)
+            addAnimation()
             
             getManagerView.getManagerCollectionView.selectedMemberList = selectManagerView.selectManagerCollectionView.selectedManagerList
             HouseWork.mockHouseWork[selectedHouseWorkIndex].manager = selectManagerView.selectManagerCollectionView.selectedManagerList
@@ -383,10 +374,7 @@ final class SetHouseWorkViewController: BaseViewController {
             timePicker.snp.updateConstraints {
                 $0.height.equalTo(196.2)
             }
-            
-            UIView.animate(withDuration: 0.3, delay: 0, options: .allowAnimatedContent, animations: {
-                self.view.layoutIfNeeded()
-            }, completion: nil)
+            addAnimation()
         } else {
             timePicker.snp.updateConstraints {
                 $0.height.equalTo(0)
@@ -422,10 +410,6 @@ final class SetHouseWorkViewController: BaseViewController {
             updateToWeekToday()
             HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle = RepeatType.week
             
-            UIView.animate(withDuration: 0.3, delay: 0, options: .allowAnimatedContent, animations: {
-                self.view.layoutIfNeeded()
-            }, completion: nil)
-            
             // FIXME: - Calendar View 비활성화 (개발되면 변경)
         } else {
             repeatCycleView.snp.updateConstraints {
@@ -439,11 +423,8 @@ final class SetHouseWorkViewController: BaseViewController {
             repeatCycleDayLabel.isHidden = true
             HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle = nil
             HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatPattern = nil
-            
-            UIView.animate(withDuration: 0.3, delay: 0, options: .allowAnimatedContent, animations: {
-                self.view.layoutIfNeeded()
-            }, completion: nil)
         }
+        addAnimation()
     }
     
     private func didTimeChanged() {
@@ -556,5 +537,11 @@ final class SetHouseWorkViewController: BaseViewController {
         getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[houseWork].manager
         isTimeSelected(houseWork)
         isRepeatSelected(houseWork)
+    }
+    
+    private func addAnimation() {
+        UIView.animate(withDuration: 0.4, delay: 0, options: .transitionCurlUp, animations: {
+            self.view.layoutIfNeeded()
+        }, completion: nil)
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -112,11 +112,12 @@ final class SetHouseWorkViewController: BaseViewController {
     private let repeatCycleMenu = RepeatCycleMenu()
     private let repeatCycleCollectionView = RepeatCycleCollectionView()
     private lazy var repeatCycleDayLabel: UILabel = {
-       let label = UILabel()
+        let label = UILabel()
         label.text = "매주 " + Date().dayOfWeekToKoreanString + "요일에 반복해요"
         label.textColor = .gray400
         label.font = .body2
         label.applyColor(to: Date().dayOfWeekToKoreanString + "요일", with: .positive20)
+        label.isHidden = true
         return label
     }()
     
@@ -192,14 +193,14 @@ final class SetHouseWorkViewController: BaseViewController {
         repeatCycleView.snp.makeConstraints {
             $0.top.equalTo(setRepeatLabel.snp.bottom).offset(SizeLiteral.componentPadding)
             $0.leading.trailing.equalToSuperview().inset(31.5)
-            $0.height.equalTo(36)
+            $0.height.equalTo(0)
         }
         
         view.addSubview(repeatCycleCollectionView)
         repeatCycleCollectionView.snp.makeConstraints {
             $0.top.equalTo(repeatCycleView.snp.bottom).offset(8)
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(40)
+            $0.height.equalTo(0)
         }
         
         view.addSubview(repeatCycleMenu)
@@ -313,7 +314,38 @@ final class SetHouseWorkViewController: BaseViewController {
     }
     
     private func didTappedRepeatToggle() {
-        
+        if setRepeatToggle.isOn {
+            repeatCycleView.snp.updateConstraints {
+                $0.height.equalTo(36)
+            }
+            repeatCycleView.repeatCycleButton.isHidden = false
+            repeatCycleView.repeatCycleLabel.isHidden = false
+            repeatCycleCollectionView.snp.updateConstraints {
+                $0.height.equalTo(40)
+            }
+            repeatCycleDayLabel.isHidden = false
+            repeatCycleDayLabel.text = "매주 " + Date().dayOfWeekToKoreanString + "요일에 반복해요"
+            repeatCycleDayLabel.applyColor(to: Date().dayOfWeekToKoreanString, with: .positive20)
+            repeatCycleCollectionView.selectedDaysOfWeek = []
+            
+            UIView.animate(withDuration: 0.3, delay: 0, options: .allowAnimatedContent, animations: {
+                self.view.layoutIfNeeded()
+            }, completion: nil)
+        } else {
+            repeatCycleView.snp.updateConstraints {
+                $0.height.equalTo(0)
+            }
+            repeatCycleView.repeatCycleButton.isHidden = true
+            repeatCycleView.repeatCycleLabel.isHidden = true
+            repeatCycleCollectionView.snp.updateConstraints {
+                $0.height.equalTo(0)
+            }
+            repeatCycleDayLabel.isHidden = true
+            
+            UIView.animate(withDuration: 0.3, delay: 0, options: .allowAnimatedContent, animations: {
+                self.view.layoutIfNeeded()
+            }, completion: nil)
+        }
     }
     
     private func didChangedTime() {
@@ -338,7 +370,6 @@ final class SetHouseWorkViewController: BaseViewController {
                 
                 self?.repeatCycleDayLabel.text = "매달 " + Date().singleDayToKoreanString + "에 반복해요"
                 self?.repeatCycleDayLabel.applyColor(to: Date().singleDayToKoreanString, with: .positive20)
-                self?.repeatCycleCollectionView.selectedDaysOfWeek = []
             } else {
                 self?.repeatCycleCollectionView.snp.updateConstraints {
                     $0.height.equalTo(40)
@@ -346,6 +377,7 @@ final class SetHouseWorkViewController: BaseViewController {
                 
                 self?.repeatCycleDayLabel.text = "매주 " + Date().dayOfWeekToKoreanString + "요일에 반복해요"
                 self?.repeatCycleDayLabel.applyColor(to: Date().dayOfWeekToKoreanString, with: .positive20)
+                self?.repeatCycleCollectionView.selectedDaysOfWeek = []
             }
             self?.repeatCycleView.repeatCycleButtonLabel.text = repeatCycle
             self?.repeatCycleMenu.isHidden = true

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -66,12 +66,16 @@ final class SetHouseWorkViewController: BaseViewController {
         toggle.addAction(action, for: .touchUpInside)
         return toggle
     }()
-    private let timePicker: UIDatePicker = {
+    private lazy var timePicker: UIDatePicker = {
         let picker = UIDatePicker()
         picker.preferredDatePickerStyle = .wheels
         picker.datePickerMode = .time
         picker.locale = Locale(identifier: "ko-KR")
         picker.timeZone = .autoupdatingCurrent
+        let action = UIAction { [weak self] _ in
+            self?.didChangedTime()
+        }
+        picker.addAction(action, for: .valueChanged)
         return picker
     }()
     private let divider: UIView = {
@@ -258,5 +262,14 @@ final class SetHouseWorkViewController: BaseViewController {
     
     private func didTappedRepeatToggle() {
         
+    }
+    
+    private func didChangedTime() {
+        let dateformatter = DateFormatter()
+        dateformatter.dateStyle = .none
+        dateformatter.timeStyle = .short
+        let date = timePicker.date.timeToKoreanString
+        // FIXME: - 모델 생성 후 CollectionView에 시간 반영
+        print(date)
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -26,6 +26,8 @@ final class SetHouseWorkViewController: BaseViewController {
         view.addManagerButton.addAction(action, for: .touchUpInside)
         return view
     }()
+    private let scrollView = UIScrollView()
+    private let contentView = UIView()
     private lazy var selectManagerView: SelectManagerView = {
         let view = SelectManagerView()
         let cancelAction = UIAction { [weak self] _ in
@@ -120,6 +122,12 @@ final class SetHouseWorkViewController: BaseViewController {
         label.isHidden = true
         return label
     }()
+    private let doneButton: MainButton = {
+        let button = MainButton()
+        button.title = "집안일 추가 완료"
+        button.isDisabled = false
+        return button
+    }()
     
     // MARK: - life cycle
     
@@ -141,71 +149,90 @@ final class SetHouseWorkViewController: BaseViewController {
         
         view.addSubview(setHouseWorkCollectionView)
         setHouseWorkCollectionView.snp.makeConstraints {
-            $0.top.equalTo(setHouseWorkCalendarView.snp.bottom).offset(8)
+            $0.top.equalTo(setHouseWorkCalendarView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(134)
         }
         
-        view.addSubview(getManagerView)
-        getManagerView.snp.makeConstraints {
+        view.addSubview(doneButton)
+        doneButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(SizeLiteral.componentPadding)
+        }
+        
+        view.addSubview(scrollView)
+        scrollView.snp.makeConstraints {
             $0.top.equalTo(setHouseWorkCollectionView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(doneButton.snp.top).inset(-SizeLiteral.componentPadding)
+        }
+        
+        scrollView.addSubview(contentView)
+        contentView.snp.makeConstraints {
+            $0.width.edges.equalToSuperview()
+        }
+        
+        contentView.addSubview(getManagerView)
+        getManagerView.snp.makeConstraints {
+            $0.top.equalToSuperview()
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(120)
         }
         
-        view.addSubview(setTimeLabel)
+        contentView.addSubview(setTimeLabel)
         setTimeLabel.snp.makeConstraints {
             $0.top.equalTo(getManagerView.snp.bottom).offset(SizeLiteral.componentPadding)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
-        view.addSubview(setTimeToggle)
+        contentView.addSubview(setTimeToggle)
         setTimeToggle.snp.makeConstraints {
             $0.centerY.equalTo(setTimeLabel.snp.centerY)
             $0.trailing.equalToSuperview().inset(20)
         }
         
-        view.addSubview(timePicker)
+        contentView.addSubview(timePicker)
         timePicker.snp.makeConstraints {
             $0.top.equalTo(setTimeLabel.snp.bottom).offset(12)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.height.equalTo(0)
         }
         
-        view.addSubview(divider)
+        contentView.addSubview(divider)
         divider.snp.makeConstraints {
             $0.top.equalTo(timePicker.snp.bottom).offset(SizeLiteral.componentPadding)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.height.equalTo(2)
         }
         
-        view.addSubview(setRepeatLabel)
+        contentView.addSubview(setRepeatLabel)
         setRepeatLabel.snp.makeConstraints {
             $0.top.equalTo(divider.snp.bottom).offset(SizeLiteral.componentPadding)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.bottom.equalTo(0)
         }
         
-        view.addSubview(setRepeatToggle)
+        contentView.addSubview(setRepeatToggle)
         setRepeatToggle.snp.makeConstraints {
             $0.centerY.equalTo(setRepeatLabel.snp.centerY)
             $0.trailing.equalToSuperview().inset(20)
         }
         
-        view.addSubview(repeatCycleView)
+        contentView.addSubview(repeatCycleView)
         repeatCycleView.snp.makeConstraints {
             $0.top.equalTo(setRepeatLabel.snp.bottom).offset(SizeLiteral.componentPadding)
             $0.leading.trailing.equalToSuperview().inset(31.5)
             $0.height.equalTo(0)
         }
         
-        view.addSubview(repeatCycleCollectionView)
+        contentView.addSubview(repeatCycleCollectionView)
         repeatCycleCollectionView.snp.makeConstraints {
             $0.top.equalTo(repeatCycleView.snp.bottom).offset(8)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(0)
         }
         
-        view.addSubview(repeatCycleMenu)
+        contentView.addSubview(repeatCycleMenu)
         repeatCycleMenu.snp.makeConstraints {
             $0.top.equalTo(repeatCycleView.snp.bottom)
             $0.trailing.equalToSuperview().inset(31.5)
@@ -213,7 +240,7 @@ final class SetHouseWorkViewController: BaseViewController {
             $0.height.equalTo(76)
         }
         
-        view.addSubview(repeatCycleDayLabel)
+        contentView.addSubview(repeatCycleDayLabel)
         repeatCycleDayLabel.snp.makeConstraints {
             $0.top.equalTo(repeatCycleCollectionView.snp.bottom).offset(16)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
@@ -225,7 +252,7 @@ final class SetHouseWorkViewController: BaseViewController {
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(0)
         }
-        
+
         view.addSubview(managerToastLabel)
         managerToastLabel.snp.makeConstraints {
             $0.bottom.equalTo(selectManagerView.snp.top).offset(-10)
@@ -396,6 +423,16 @@ final class SetHouseWorkViewController: BaseViewController {
                 $0.height.equalTo(40)
             }
             repeatCycleDayLabel.isHidden = false
+            repeatCycleDayLabel.snp.remakeConstraints {
+                $0.top.equalTo(repeatCycleCollectionView.snp.bottom).offset(16)
+                $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+                $0.height.equalTo(22)
+                $0.bottom.equalTo(0)
+            }
+            setRepeatLabel.snp.remakeConstraints {
+                $0.top.equalTo(divider.snp.bottom).offset(SizeLiteral.componentPadding)
+                $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            }
             updateToWeekToday()
             HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle = "매주"
             

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -268,19 +268,61 @@ final class SetHouseWorkViewController: BaseViewController {
             }
             
             self?.isTimeSelected(selectedHouseWorkIndex)
+            self?.repeatCycleCollectionView.selectedHouseWorkIndex = selectedHouseWorkIndex
+            self?.repeatCycleCollectionView.collectionView.reloadData()
+            if HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle == nil {
+                self?.setRepeatToggle.isOn = false
+                self?.repeatCycleView.snp.updateConstraints {
+                    $0.height.equalTo(0)
+                }
+                self?.repeatCycleView.repeatCycleButton.isHidden = true
+                self?.repeatCycleView.repeatCycleLabel.isHidden = true
+                self?.repeatCycleCollectionView.snp.updateConstraints {
+                    $0.height.equalTo(0)
+                }
+                self?.repeatCycleDayLabel.isHidden = true
+            } else {
+                self?.setRepeatToggle.isOn = true
+                self?.repeatCycleView.snp.updateConstraints {
+                    $0.height.equalTo(36)
+                }
+                self?.repeatCycleView.repeatCycleButton.isHidden = false
+                self?.repeatCycleView.repeatCycleLabel.isHidden = false
+                self?.repeatCycleCollectionView.snp.updateConstraints {
+                    $0.height.equalTo(40)
+                }
+                self?.repeatCycleDayLabel.isHidden = false
+                let selectedDays = HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatPattern?.joined(separator: ", ")
+                self?.repeatCycleDayLabel.text = "매주 " + (selectedDays ?? Date().dayOfWeekToKoreanString) + "요일에 반복해요"
+                self?.repeatCycleDayLabel.applyColor(to: (selectedDays ?? Date().dayOfWeekToKoreanString) + "요일", with: .positive20)
+            }
         }
     }
     
     private func didDeleteHouseWork() {
         setHouseWorkCollectionView.didDeleteHouseWork = { [weak self] deletedHouseWorkIndex in
+            print(self?.selectedHouseWorkIndex)
+            print(deletedHouseWorkIndex)
             if HouseWork.mockHouseWork.count == 0 {
                 // FIXME: - 이전 페이지로 이동
-            } else if deletedHouseWorkIndex == HouseWork.mockHouseWork.endIndex {
+            } else if deletedHouseWorkIndex == HouseWork.mockHouseWork.endIndex && deletedHouseWorkIndex == self?.selectedHouseWorkIndex ?? 0 {
                 self?.getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[deletedHouseWorkIndex - 1].manager
                 self?.isTimeSelected(deletedHouseWorkIndex - 1)
-            } else {
+                self?.isRepeatSelected(deletedHouseWorkIndex - 1)
+                self?.selectedHouseWorkIndex -= 1
+            } else if deletedHouseWorkIndex < self?.selectedHouseWorkIndex ?? 0 {
+                self?.getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[(self?.selectedHouseWorkIndex ?? 0) - 1].manager
+                self?.isTimeSelected((self?.selectedHouseWorkIndex ?? 0) - 1)
+                self?.isRepeatSelected((self?.selectedHouseWorkIndex ?? 0) - 1)
+                self?.selectedHouseWorkIndex -= 1
+            } else if deletedHouseWorkIndex == self?.selectedHouseWorkIndex {
                 self?.getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[deletedHouseWorkIndex].manager
                 self?.isTimeSelected(deletedHouseWorkIndex)
+                self?.isRepeatSelected(deletedHouseWorkIndex)
+            } else {
+                self?.getManagerView.getManagerCollectionView.selectedMemberList = HouseWork.mockHouseWork[self?.selectedHouseWorkIndex ?? 0].manager
+                self?.isTimeSelected(self?.selectedHouseWorkIndex ?? 0)
+                self?.isRepeatSelected(self?.selectedHouseWorkIndex ?? 0)
             }
         }
     }
@@ -339,8 +381,10 @@ final class SetHouseWorkViewController: BaseViewController {
             timePicker.snp.updateConstraints {
                 $0.height.equalTo(0)
             }
+            
+            HouseWork.mockHouseWork[selectedHouseWorkIndex].time = "하루 종일"
+            setHouseWorkCollectionView.collectionView.reloadData()
         }
-        
     }
     
     private func didTappedRepeatToggle() {
@@ -355,6 +399,7 @@ final class SetHouseWorkViewController: BaseViewController {
             }
             repeatCycleDayLabel.isHidden = false
             updateToWeekToday()
+            HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle = "매주"
             
             UIView.animate(withDuration: 0.3, delay: 0, options: .allowAnimatedContent, animations: {
                 self.view.layoutIfNeeded()
@@ -369,6 +414,8 @@ final class SetHouseWorkViewController: BaseViewController {
                 $0.height.equalTo(0)
             }
             repeatCycleDayLabel.isHidden = true
+            HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle = nil
+            HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatPattern = nil
             
             UIView.animate(withDuration: 0.3, delay: 0, options: .allowAnimatedContent, animations: {
                 self.view.layoutIfNeeded()
@@ -414,6 +461,7 @@ final class SetHouseWorkViewController: BaseViewController {
             let selectedDaysOfWeek = selectedDays.isEmpty ? Date().dayOfWeekToKoreanString : selectedDays.joined(separator: ", ")
             self?.repeatCycleDayLabel.text = "매주 " + selectedDaysOfWeek + "요일에 반복해요"
             self?.repeatCycleDayLabel.applyColor(to: selectedDaysOfWeek + "요일", with: .positive20)
+            HouseWork.mockHouseWork[self?.selectedHouseWorkIndex ?? 0].repeatPattern = selectedDays
         }
     }
     
@@ -439,6 +487,39 @@ final class SetHouseWorkViewController: BaseViewController {
             timePicker.snp.updateConstraints {
                 $0.height.equalTo(196.2)
             }
+        }
+    }
+    
+    private func isRepeatSelected(_ houseWork: Int) {
+        if HouseWork.mockHouseWork[houseWork].repeatCycle == nil {
+            setRepeatToggle.isOn = false
+            repeatCycleView.snp.updateConstraints {
+                $0.height.equalTo(0)
+            }
+            repeatCycleView.repeatCycleButton.isHidden = true
+            repeatCycleView.repeatCycleLabel.isHidden = true
+            repeatCycleCollectionView.snp.updateConstraints {
+                $0.height.equalTo(0)
+            }
+            repeatCycleDayLabel.isHidden = true
+        } else {
+            setRepeatToggle.isOn = true
+            repeatCycleView.snp.updateConstraints {
+                $0.height.equalTo(36)
+            }
+            repeatCycleView.repeatCycleButton.isHidden = false
+            repeatCycleView.repeatCycleLabel.isHidden = false
+            repeatCycleCollectionView.snp.updateConstraints {
+                $0.height.equalTo(40)
+            }
+            repeatCycleDayLabel.isHidden = false
+            let selectedDays = HouseWork.mockHouseWork[houseWork].repeatPattern?.joined(separator: ", ")
+            repeatCycleDayLabel.text = "매주 " + (selectedDays ?? Date().dayOfWeekToKoreanString) + "요일에 반복해요"
+            repeatCycleDayLabel.applyColor(to: (selectedDays ?? Date().dayOfWeekToKoreanString) + "요일", with: .positive20)
+            
+            repeatCycleCollectionView.selectedHouseWorkIndex = houseWork
+            repeatCycleCollectionView.collectionView.reloadData()
+            print(selectedHouseWorkIndex)
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
@@ -12,10 +12,11 @@ import SnapKit
 final class RepeatCycleCollectionView: BaseUIView {
     
     private let daysOfWeek: [String] = ["월", "화", "수", "목", "금", "토", "일"]
+    var selectedDaysOfWeek: [String] = []
     
     private enum Size {
         static let collectionHorizontalSpacing: CGFloat = 31.5
-        static let collectionVerticalSpacing: CGFloat = 0
+        static let collectionVerticalSpacing: CGFloat = 8
         static let cellLength: CGFloat = 40
         static let collectionInsets = UIEdgeInsets(
             top: collectionVerticalSpacing,
@@ -58,7 +59,14 @@ final class RepeatCycleCollectionView: BaseUIView {
 
 extension RepeatCycleCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        print(daysOfWeek[indexPath.item])
+        selectedDaysOfWeek.append(daysOfWeek[indexPath.item])
+        print(selectedDaysOfWeek)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+        selectedDaysOfWeek.removeAll(where: { $0 == daysOfWeek[indexPath.item]})
+        print(selectedDaysOfWeek)
+
     }
 }
 

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
@@ -58,6 +58,7 @@ final class RepeatCycleCollectionView: BaseUIView {
 
 extension RepeatCycleCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        print(daysOfWeek[indexPath.item])
     }
 }
 

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
@@ -26,7 +26,7 @@ final class RepeatCycleCollectionView: BaseUIView {
     var didSelectDaysOfWeek: (([String]) -> ())?
     
     private enum Size {
-        static let collectionHorizontalSpacing: CGFloat = 31.5
+        static let collectionHorizontalSpacing: CGFloat = 24
         static let collectionVerticalSpacing: CGFloat = 0
         static let cellLength: CGFloat = 40
         static let collectionInsets = UIEdgeInsets(
@@ -43,7 +43,7 @@ final class RepeatCycleCollectionView: BaseUIView {
         flowLayout.sectionInset = Size.collectionInsets
         flowLayout.itemSize = CGSize(width: Size.cellLength, height: Size.cellLength)
         flowLayout.scrollDirection = .vertical
-        flowLayout.minimumInteritemSpacing = 5.33
+        flowLayout.minimumInteritemSpacing = 7.83
         return flowLayout
     }()
     lazy var collectionView: UICollectionView = {

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
@@ -17,7 +17,7 @@ final class RepeatCycleCollectionView: BaseUIView {
             selectedDaysOfWeek = HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatPattern ?? []
         }
     }
-    private let daysOfWeek: [String] = ["월", "화", "수", "목", "금", "토", "일"]
+    private let daysOfWeekList: [String] = TextLiteral.repeatCycleCollectionViewDaysOfWeekList
     var selectedDaysOfWeek: [String] = [] {
         didSet {
             collectionView.reloadData()
@@ -71,19 +71,19 @@ final class RepeatCycleCollectionView: BaseUIView {
 extension RepeatCycleCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         selectedIndex = indexPath.item
-        selectedDaysOfWeek.append(daysOfWeek[indexPath.item])
+        selectedDaysOfWeek.append(daysOfWeekList[indexPath.item])
         didSelectDaysOfWeek?(selectedDaysOfWeek)
     }
     
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-        selectedDaysOfWeek.removeAll(where: { $0 == daysOfWeek[indexPath.item]})
+        selectedDaysOfWeek.removeAll(where: { $0 == daysOfWeekList[indexPath.item]})
         didSelectDaysOfWeek?(selectedDaysOfWeek)
     }
 }
 
 extension RepeatCycleCollectionView: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return daysOfWeek.count
+        return daysOfWeekList.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -93,13 +93,13 @@ extension RepeatCycleCollectionView: UICollectionViewDataSource {
         }
         
         if let houseWorkPattern = HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatPattern {
-            if houseWorkPattern.contains(daysOfWeek[indexPath.item]) {
+            if houseWorkPattern.contains(daysOfWeekList[indexPath.item]) {
                 cell.isSelected = true
                 collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .init())
             }
         }
         
-        cell.weekOfDayLabel.text = daysOfWeek[indexPath.item]
+        cell.weekOfDayLabel.text = daysOfWeekList[indexPath.item]
         
         return cell
     }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
@@ -12,7 +12,11 @@ import SnapKit
 final class RepeatCycleCollectionView: BaseUIView {
     
     var selectedIndex: Int?
-    var selectedHouseWorkIndex: Int = 0
+    var selectedHouseWorkIndex: Int = 0 {
+        didSet {
+            selectedDaysOfWeek = HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatPattern ?? []
+        }
+    }
     private let daysOfWeek: [String] = ["월", "화", "수", "목", "금", "토", "일"]
     var selectedDaysOfWeek: [String] = [] {
         didSet {

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
@@ -12,7 +12,8 @@ import SnapKit
 final class RepeatCycleCollectionView: BaseUIView {
     
     private let daysOfWeek: [String] = ["월", "화", "수", "목", "금", "토", "일"]
-    var selectedDaysOfWeek: [String] = []
+    private var selectedDaysOfWeek: [String] = []
+    var didSelectDaysOfWeek: (([String]) -> ())?
     
     private enum Size {
         static let collectionHorizontalSpacing: CGFloat = 31.5
@@ -60,12 +61,12 @@ final class RepeatCycleCollectionView: BaseUIView {
 extension RepeatCycleCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         selectedDaysOfWeek.append(daysOfWeek[indexPath.item])
-        print(selectedDaysOfWeek)
+        didSelectDaysOfWeek?(selectedDaysOfWeek)
     }
     
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         selectedDaysOfWeek.removeAll(where: { $0 == daysOfWeek[indexPath.item]})
-        print(selectedDaysOfWeek)
+        didSelectDaysOfWeek?(selectedDaysOfWeek)
 
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
@@ -15,7 +15,7 @@ final class RepeatCycleCollectionView: BaseUIView {
     
     private enum Size {
         static let collectionHorizontalSpacing: CGFloat = 31.5
-        static let collectionVerticalSpacing: CGFloat = 8
+        static let collectionVerticalSpacing: CGFloat = 0
         static let cellLength: CGFloat = 40
         static let collectionInsets = UIEdgeInsets(
             top: collectionVerticalSpacing,

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
@@ -11,13 +11,18 @@ import SnapKit
 
 final class RepeatCycleCollectionView: BaseUIView {
     
+    var selectedIndex: Int?
     private let daysOfWeek: [String] = ["월", "화", "수", "목", "금", "토", "일"]
-    private var selectedDaysOfWeek: [String] = []
+    var selectedDaysOfWeek: [String] = [] {
+        didSet {
+            collectionView.reloadData()
+        }
+    }
     var didSelectDaysOfWeek: (([String]) -> ())?
     
     private enum Size {
         static let collectionHorizontalSpacing: CGFloat = 31.5
-        static let collectionVerticalSpacing: CGFloat = 8
+        static let collectionVerticalSpacing: CGFloat = 0
         static let cellLength: CGFloat = 40
         static let collectionInsets = UIEdgeInsets(
             top: collectionVerticalSpacing,
@@ -60,6 +65,7 @@ final class RepeatCycleCollectionView: BaseUIView {
 
 extension RepeatCycleCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        selectedIndex = indexPath.item
         selectedDaysOfWeek.append(daysOfWeek[indexPath.item])
         didSelectDaysOfWeek?(selectedDaysOfWeek)
     }
@@ -67,7 +73,6 @@ extension RepeatCycleCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         selectedDaysOfWeek.removeAll(where: { $0 == daysOfWeek[indexPath.item]})
         didSelectDaysOfWeek?(selectedDaysOfWeek)
-
     }
 }
 
@@ -80,6 +85,11 @@ extension RepeatCycleCollectionView: UICollectionViewDataSource {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RepeatCycleCollectionViewCell.className, for: indexPath) as? RepeatCycleCollectionViewCell else {
             assert(false, "Wrong Cell")
             return UICollectionViewCell()
+        }
+        
+        if selectedDaysOfWeek.contains(daysOfWeek[indexPath.item]) {
+            cell.isSelected = true
+            collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .init())
         }
         
         cell.weekOfDayLabel.text = daysOfWeek[indexPath.item]

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
@@ -12,6 +12,7 @@ import SnapKit
 final class RepeatCycleCollectionView: BaseUIView {
     
     var selectedIndex: Int?
+    var selectedHouseWorkIndex: Int = 0
     private let daysOfWeek: [String] = ["월", "화", "수", "목", "금", "토", "일"]
     var selectedDaysOfWeek: [String] = [] {
         didSet {
@@ -41,7 +42,7 @@ final class RepeatCycleCollectionView: BaseUIView {
         flowLayout.minimumInteritemSpacing = 5.33
         return flowLayout
     }()
-    private lazy var collectionView: UICollectionView = {
+    lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
         collectionView.backgroundColor = .clear
         collectionView.delegate = self
@@ -87,9 +88,11 @@ extension RepeatCycleCollectionView: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
         
-        if selectedDaysOfWeek.contains(daysOfWeek[indexPath.item]) {
-            cell.isSelected = true
-            collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .init())
+        if let houseWorkPattern = HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatPattern {
+            if houseWorkPattern.contains(daysOfWeek[indexPath.item]) {
+                cell.isSelected = true
+                collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .init())
+            }
         }
         
         cell.weekOfDayLabel.text = daysOfWeek[indexPath.item]

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
@@ -93,13 +93,13 @@ extension RepeatCycleCollectionView: UICollectionViewDataSource {
         }
         
         if let houseWorkPattern = HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatPattern {
-            if houseWorkPattern.contains(daysOfWeekList[indexPath.item]) {
+            if houseWorkPattern.contains(String(daysOfWeekList[indexPath.item].dropFirst(1))) {
                 cell.isSelected = true
                 collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .init())
             }
         }
         
-        cell.weekOfDayLabel.text = daysOfWeekList[indexPath.item]
+        cell.weekOfDayLabel.text = String(daysOfWeekList[indexPath.item].dropFirst(1))
         
         return cell
     }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionView.swift
@@ -1,0 +1,79 @@
+//
+//  RepeatCycleCollectionView.swift
+//  fairer-iOS
+//
+//  Created by 김유나 on 2023/01/27.
+//
+
+import UIKit
+
+import SnapKit
+
+final class RepeatCycleCollectionView: BaseUIView {
+    
+    private let daysOfWeek: [String] = ["월", "화", "수", "목", "금", "토", "일"]
+    
+    private enum Size {
+        static let collectionHorizontalSpacing: CGFloat = 31.5
+        static let collectionVerticalSpacing: CGFloat = 8
+        static let cellLength: CGFloat = 40
+        static let collectionInsets = UIEdgeInsets(
+            top: collectionVerticalSpacing,
+            left: collectionHorizontalSpacing,
+            bottom: collectionVerticalSpacing,
+            right: collectionHorizontalSpacing)
+    }
+    
+    // MARK: - property
+    
+    private let collectionViewFlowLayout: UICollectionViewFlowLayout = {
+        let flowLayout = UICollectionViewFlowLayout()
+        flowLayout.sectionInset = Size.collectionInsets
+        flowLayout.itemSize = CGSize(width: Size.cellLength, height: Size.cellLength)
+        flowLayout.scrollDirection = .vertical
+        flowLayout.minimumInteritemSpacing = 5.33
+        return flowLayout
+    }()
+    private lazy var collectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
+        collectionView.backgroundColor = .clear
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.register(RepeatCycleCollectionViewCell.self, forCellWithReuseIdentifier: RepeatCycleCollectionViewCell.className)
+        collectionView.allowsMultipleSelection = true
+        return collectionView
+    }()
+    
+    // MARK: - life cycle
+    
+    override func render() {
+        self.addSubview(collectionView)
+        collectionView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}
+
+// MARK: - extension
+
+extension RepeatCycleCollectionView: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    }
+}
+
+extension RepeatCycleCollectionView: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return daysOfWeek.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RepeatCycleCollectionViewCell.className, for: indexPath) as? RepeatCycleCollectionViewCell else {
+            assert(false, "Wrong Cell")
+            return UICollectionViewCell()
+        }
+        
+        cell.weekOfDayLabel.text = daysOfWeek[indexPath.item]
+        
+        return cell
+    }
+}

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionViewCell.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionViewCell.swift
@@ -1,0 +1,38 @@
+//
+//  RepeatCycleCollectionViewCell.swift
+//  fairer-iOS
+//
+//  Created by 김유나 on 2023/01/27.
+//
+
+import UIKit
+
+import SnapKit
+
+final class RepeatCycleCollectionViewCell: BaseCollectionViewCell {
+    
+    // MARK: - property
+    
+    let weekOfDayLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .gray600
+        label.font = .body2
+        return label
+    }()
+    
+    // MARK: - life cycle
+    
+    override func render() {
+        self.addSubview(weekOfDayLabel)
+        weekOfDayLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+    }
+    
+    override func configUI() {
+        self.backgroundColor = .white
+        self.layer.borderWidth = 1
+        self.layer.borderColor = UIColor.gray200.cgColor
+        self.layer.cornerRadius = 6
+    }
+}

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionViewCell.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleCollectionViewCell.swift
@@ -11,6 +11,16 @@ import SnapKit
 
 final class RepeatCycleCollectionViewCell: BaseCollectionViewCell {
     
+    override var isSelected: Bool {
+        didSet {
+            if isSelected {
+                setSelectedCellLayer()
+            } else {
+                setShadowCellLayer()
+            }
+        }
+    }
+    
     // MARK: - property
     
     let weekOfDayLabel: UILabel = {
@@ -34,5 +44,19 @@ final class RepeatCycleCollectionViewCell: BaseCollectionViewCell {
         self.layer.borderWidth = 1
         self.layer.borderColor = UIColor.gray200.cgColor
         self.layer.cornerRadius = 6
+    }
+    
+    // MARK: - func
+    
+    private func setSelectedCellLayer() {
+        self.backgroundColor = .positive10
+        self.layer.borderColor = UIColor.blue.cgColor
+        self.weekOfDayLabel.textColor = .blue
+    }
+    
+    private func setShadowCellLayer() {
+        self.backgroundColor = .white
+        self.layer.borderColor = UIColor.gray200.cgColor
+        self.weekOfDayLabel.textColor = .gray600
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleMenu.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleMenu.swift
@@ -1,0 +1,76 @@
+//
+//  RepeatCycleMenu.swift
+//  fairer-iOS
+//
+//  Created by 김유나 on 2023/01/27.
+//
+
+import UIKit
+
+import SnapKit
+
+final class RepeatCycleMenu: BaseUIView {
+    
+    var didTappedRepeatCycleMenuButton: ((String) -> ())?
+    // MARK: - property
+    
+    private lazy var everyWeekButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("매주", for: .normal)
+        button.setTitleColor(.gray600, for: .normal)
+        button.titleLabel?.font = .body2
+        let action = UIAction { [weak self] _ in
+            self?.didTappedRepeatCycleMenuButton?("매주")
+        }
+        button.addAction(action, for: .touchUpInside)
+        return button
+    }()
+    private let divider: UIView = {
+        let view = UIView()
+        view.backgroundColor = .gray100
+        return view
+    }()
+    private lazy var everyMonthButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("매달", for: .normal)
+        button.setTitleColor(.gray600, for: .normal)
+        button.titleLabel?.font = .body2
+        let action = UIAction { [weak self] _ in
+            self?.didTappedRepeatCycleMenuButton?("매달")
+        }
+        button.addAction(action, for: .touchUpInside)
+        return button
+    }()
+    
+    // MARK: - life cycle
+    
+    override func render() {
+        self.addSubview(everyWeekButton)
+        everyWeekButton.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(5)
+            $0.leading.equalToSuperview().inset(16)
+        }
+        
+        self.addSubview(divider)
+        divider.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(1)
+        }
+        
+        self.addSubview(everyMonthButton)
+        everyMonthButton.snp.makeConstraints {
+            $0.top.equalTo(divider.snp.bottom).offset(4)
+            $0.leading.equalToSuperview().inset(16)
+        }
+    }
+    
+    override func configUI() {
+        self.backgroundColor = .white
+        self.layer.cornerRadius = 4
+        self.layer.shadowOpacity = 0.1
+        self.layer.shadowRadius = 8
+        self.layer.shadowOffset = CGSize(width: 0, height: 4)
+        self.isHidden = true
+    }
+}

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleMenu.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleMenu.swift
@@ -12,6 +12,7 @@ import SnapKit
 final class RepeatCycleMenu: BaseUIView {
     
     var didTappedRepeatCycleMenuButton: ((String) -> ())?
+    
     // MARK: - property
     
     private lazy var everyWeekButton: UIButton = {

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleMenu.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleMenu.swift
@@ -33,7 +33,7 @@ final class RepeatCycleMenu: BaseUIView {
     }()
     private lazy var everyMonthButton: UIButton = {
         let button = UIButton()
-        button.setTitle("매달", for: .normal)
+        button.setTitle(RepeatType.month.rawValue, for: .normal)
         button.setTitleColor(.gray600, for: .normal)
         button.titleLabel?.font = .body2
         let action = UIAction { [weak self] _ in
@@ -46,20 +46,19 @@ final class RepeatCycleMenu: BaseUIView {
     // MARK: - life cycle
     
     override func render() {
-        self.addSubview(everyWeekButton)
+        self.addSubviews(everyWeekButton, divider, everyMonthButton)
+        
         everyWeekButton.snp.makeConstraints {
             $0.top.equalToSuperview().inset(5)
             $0.leading.equalToSuperview().inset(16)
         }
         
-        self.addSubview(divider)
         divider.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(1)
         }
         
-        self.addSubview(everyMonthButton)
         everyMonthButton.snp.makeConstraints {
             $0.top.equalTo(divider.snp.bottom).offset(4)
             $0.leading.equalToSuperview().inset(16)

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleMenu.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleMenu.swift
@@ -11,17 +11,17 @@ import SnapKit
 
 final class RepeatCycleMenu: BaseUIView {
     
-    var didTappedRepeatCycleMenuButton: ((String) -> ())?
+    var didTappedRepeatCycleMenuButton: ((RepeatType) -> ())?
     
     // MARK: - property
     
     private lazy var everyWeekButton: UIButton = {
         let button = UIButton()
-        button.setTitle("매주", for: .normal)
+        button.setTitle(RepeatType.week.rawValue, for: .normal)
         button.setTitleColor(.gray600, for: .normal)
         button.titleLabel?.font = .body2
         let action = UIAction { [weak self] _ in
-            self?.didTappedRepeatCycleMenuButton?("매주")
+            self?.didTappedRepeatCycleMenuButton?(.week)
         }
         button.addAction(action, for: .touchUpInside)
         return button
@@ -37,7 +37,7 @@ final class RepeatCycleMenu: BaseUIView {
         button.setTitleColor(.gray600, for: .normal)
         button.titleLabel?.font = .body2
         let action = UIAction { [weak self] _ in
-            self?.didTappedRepeatCycleMenuButton?("매달")
+            self?.didTappedRepeatCycleMenuButton?(.month)
         }
         button.addAction(action, for: .touchUpInside)
         return button

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleView.swift
@@ -57,8 +57,6 @@ final class RepeatCycleView: BaseUIView {
         repeatCycleButton.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(16)
             $0.centerY.equalToSuperview()
-            $0.width.equalTo(45)
-            $0.height.equalTo(20)
         }
         
         repeatCycleButton.addSubview(repeatCycleButtonLabel)

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleView.swift
@@ -1,0 +1,19 @@
+//
+//  RepeatCycleView.swift
+//  fairer-iOS
+//
+//  Created by 김유나 on 2023/01/26.
+//
+
+import UIKit
+
+import SnapKit
+
+final class RepeatCycleView: UIView {
+    
+    // MARK: - property
+    
+    // MARK: - life cycle
+    
+    // MARK: - func
+}

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleView.swift
@@ -21,7 +21,7 @@ final class RepeatCycleView: BaseUIView {
         return label
     }()
     let repeatCycleButton = UIButton()
-    private let repeatCycleButtonLabel: UILabel = {
+    let repeatCycleButtonLabel: UILabel = {
         let label = UILabel()
         label.text = "매주"
         label.textColor = .gray300

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleView.swift
@@ -20,7 +20,7 @@ final class RepeatCycleView: BaseUIView {
     
     let repeatCycleLabel: UILabel = {
         let label = UILabel()
-        label.text = "반복주기"
+        label.text = TextLiteral.repeatCycleViewRepeatCycleLabel
         label.textColor = .gray600
         label.font = .title2
         label.isHidden = true
@@ -33,7 +33,6 @@ final class RepeatCycleView: BaseUIView {
     }()
     let repeatCycleButtonLabel: UILabel = {
         let label = UILabel()
-        label.text = RepeatType.week.rawValue
         label.textColor = .gray300
         label.font = .title2
         return label
@@ -47,25 +46,24 @@ final class RepeatCycleView: BaseUIView {
     // MARK: - life cycle
     
     override func render() {
-        self.addSubview(repeatCycleLabel)
+        self.addSubviews(repeatCycleLabel, repeatCycleButton)
+        repeatCycleButton.addSubviews(repeatCycleButtonLabel, repeatCycleButtonChevron)
+        
         repeatCycleLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(16)
             $0.centerY.equalToSuperview()
         }
         
-        self.addSubview(repeatCycleButton)
         repeatCycleButton.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(16)
             $0.centerY.equalToSuperview()
         }
         
-        repeatCycleButton.addSubview(repeatCycleButtonLabel)
         repeatCycleButtonLabel.snp.makeConstraints {
             $0.leading.equalToSuperview()
             $0.centerY.equalToSuperview()
         }
         
-        repeatCycleButton.addSubview(repeatCycleButtonChevron)
         repeatCycleButtonChevron.snp.makeConstraints {
             $0.trailing.equalToSuperview()
             $0.centerY.equalToSuperview()

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleView.swift
@@ -9,11 +9,64 @@ import UIKit
 
 import SnapKit
 
-final class RepeatCycleView: UIView {
+final class RepeatCycleView: BaseUIView {
     
     // MARK: - property
     
+    private let repeatCycleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "반복주기"
+        label.textColor = .gray600
+        label.font = .title2
+        return label
+    }()
+    let repeatCycleButton = UIButton()
+    private let repeatCycleButtonLabel: UILabel = {
+        let label = UILabel()
+        label.text = "매주"
+        label.textColor = .gray300
+        label.font = .title2
+        return label
+    }()
+    private let repeatCycleButtonChevron: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = ImageLiterals.repeatCycleChevronButton
+        return imageView
+    }()
+    
     // MARK: - life cycle
     
-    // MARK: - func
+    override func render() {
+        self.addSubview(repeatCycleLabel)
+        repeatCycleLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(16)
+            $0.centerY.equalToSuperview()
+        }
+        
+        self.addSubview(repeatCycleButton)
+        repeatCycleButton.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(16)
+            $0.centerY.equalToSuperview()
+            $0.width.equalTo(45)
+            $0.height.equalTo(20)
+        }
+        
+        repeatCycleButton.addSubview(repeatCycleButtonLabel)
+        repeatCycleButtonLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.centerY.equalToSuperview()
+        }
+        
+        repeatCycleButton.addSubview(repeatCycleButtonChevron)
+        repeatCycleButtonChevron.snp.makeConstraints {
+            $0.trailing.equalToSuperview()
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(repeatCycleButtonLabel.snp.trailing).offset(4)
+        }
+    }
+    
+    override func configUI() {
+        self.backgroundColor = .normal0
+        self.layer.cornerRadius = 4
+    }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleView.swift
@@ -13,14 +13,19 @@ final class RepeatCycleView: BaseUIView {
     
     // MARK: - property
     
-    private let repeatCycleLabel: UILabel = {
+    let repeatCycleLabel: UILabel = {
         let label = UILabel()
         label.text = "반복주기"
         label.textColor = .gray600
         label.font = .title2
+        label.isHidden = true
         return label
     }()
-    let repeatCycleButton = UIButton()
+    let repeatCycleButton: UIButton = {
+        let button = UIButton()
+        button.isHidden = true
+        return button
+    }()
     let repeatCycleButtonLabel: UILabel = {
         let label = UILabel()
         label.text = "매주"

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/RepeatCycle/RepeatCycleView.swift
@@ -9,6 +9,11 @@ import UIKit
 
 import SnapKit
 
+enum RepeatType: String {
+    case week = "매주"
+    case month = "매달"
+}
+
 final class RepeatCycleView: BaseUIView {
     
     // MARK: - property
@@ -28,7 +33,7 @@ final class RepeatCycleView: BaseUIView {
     }()
     let repeatCycleButtonLabel: UILabel = {
         let label = UILabel()
-        label.text = "매주"
+        label.text = RepeatType.week.rawValue
         label.textColor = .gray300
         label.font = .title2
         return label

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SelectManagerCollectionViewCell.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SelectManagerCollectionViewCell.swift
@@ -42,20 +42,19 @@ final class SelectManagerCollectionViewCell: BaseCollectionViewCell {
     // MARK: - life cycle
     
     override func render() {
-        self.addSubview(profileImage)
+        self.addSubviews(profileImage, profileName, selectIcon)
+        
         profileImage.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.leading.equalToSuperview().inset(12)
             $0.width.height.equalTo(24)
         }
         
-        self.addSubview(profileName)
         profileName.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.leading.equalTo(profileImage.snp.trailing).offset(6)
         }
         
-        self.addSubview(selectIcon)
         selectIcon.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.trailing.equalToSuperview().inset(12)

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SelectManagerView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SelectManagerView.swift
@@ -43,20 +43,19 @@ final class SelectManagerView: BaseUIView {
     // MARK: - life cycle
     
     override func render() {
-        self.addSubview(selectManagerLabel)
+        self.addSubviews(selectManagerLabel, selectManagerCollectionView, cancelButton, confirmButton)
+        
         selectManagerLabel.snp.makeConstraints {
             $0.top.equalToSuperview().inset(20)
             $0.centerX.equalToSuperview()
         }
         
-        self.addSubview(selectManagerCollectionView)
         selectManagerCollectionView.snp.makeConstraints {
             $0.top.equalTo(selectManagerLabel.snp.bottom).offset(24)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(142)
         }
         
-        self.addSubview(cancelButton)
         cancelButton.snp.makeConstraints {
             $0.top.equalTo(selectManagerCollectionView.snp.bottom).offset(24)
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
@@ -64,7 +63,6 @@ final class SelectManagerView: BaseUIView {
             $0.height.equalTo(56)
         }
         
-        self.addSubview(confirmButton)
         confirmButton.snp.makeConstraints {
             $0.centerY.equalTo(cancelButton.snp.centerY)
             $0.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SetHouseWorkCalendarView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SetHouseWorkCalendarView.swift
@@ -53,27 +53,25 @@ final class SetHouseWorkCalendarView: BaseUIView {
     }
     
     override func render() {
-        self.addSubview(calendarPicker)
+        self.addSubviews(calendarPicker, chevron, spaceLabel, spacePin)
+        
         calendarPicker.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(5)
             $0.top.equalToSuperview()
             $0.width.equalTo(120)
         }
         
-        self.addSubview(chevron)
         chevron.snp.makeConstraints {
             $0.leading.equalTo(calendarPicker.snp.trailing).offset(-10)
             $0.centerY.equalTo(calendarPicker.snp.centerY)
             $0.width.height.equalTo(20)
         }
         
-        self.addSubview(spaceLabel)
         spaceLabel.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.centerY.equalTo(calendarPicker.snp.centerY)
         }
         
-        self.addSubview(spacePin)
         spacePin.snp.makeConstraints {
             $0.trailing.equalTo(spaceLabel.snp.leading).inset(-4)
             $0.centerY.equalTo(spaceLabel.snp.centerY)

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SetHouseWorkCalendarView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SetHouseWorkCalendarView.swift
@@ -56,7 +56,7 @@ final class SetHouseWorkCalendarView: BaseUIView {
         self.addSubview(calendarPicker)
         calendarPicker.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(5)
-            $0.top.equalToSuperview().inset(8)
+            $0.top.equalToSuperview()
             $0.width.equalTo(120)
         }
         

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SetHouseWorkCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SetHouseWorkCollectionView.swift
@@ -94,8 +94,8 @@ extension SetHouseWorkCollectionView: UICollectionViewDataSource {
         }
         
         cell.houseWorkLabel.text = HouseWork.mockHouseWork[indexPath.row].name
-        cell.timeLabel.text = HouseWork.mockHouseWork[indexPath.row].time
-        
+        cell.timeLabel.setTextWithLineHeight(text: HouseWork.mockHouseWork[indexPath.row].time, lineHeight: 18)
+
         cell.deleteButton.tag = indexPath.item
         cell.deleteButton.addTarget(self, action: #selector(didTappedDeleteButton(sender:)), for: .touchUpInside)
         

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SetHouseWorkCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SetHouseWorkCollectionView.swift
@@ -12,6 +12,7 @@ import SnapKit
 final class SetHouseWorkCollectionView: BaseUIView {
     
     var didTappedHouseWork: ((Int) -> ())?
+    var didDeleteHouseWork: ((Int) -> ())?
     
     var selectedIndex: Int = 0 {
         didSet {
@@ -19,9 +20,7 @@ final class SetHouseWorkCollectionView: BaseUIView {
         }
     }
     
-    // FIXME: - SelectHouseWorkVC에서 선택한 집안일 목록 연결
-    private var selectedDetailHouseWork = HouseWork.mockHouseWork
-    lazy var isSelectedDetailHouseWork = [selectedDetailHouseWork[selectedIndex].name]
+    lazy var isSelectedDetailHouseWork = [HouseWork.mockHouseWork[selectedIndex].name]
     
     private enum Size {
         static let collectionHorizontalSpacing: CGFloat = 24
@@ -44,7 +43,7 @@ final class SetHouseWorkCollectionView: BaseUIView {
         flowLayout.scrollDirection = .horizontal
         return flowLayout
     }()
-    private lazy var collectionView: UICollectionView = {
+    lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
         collectionView.backgroundColor = .clear
         collectionView.delegate = self
@@ -69,14 +68,14 @@ final class SetHouseWorkCollectionView: BaseUIView {
 extension SetHouseWorkCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         selectedIndex = indexPath.item
-        isSelectedDetailHouseWork.append(selectedDetailHouseWork[selectedIndex].name)
+        isSelectedDetailHouseWork.append(HouseWork.mockHouseWork[selectedIndex].name)
         didTappedHouseWork?(selectedIndex)
     }
 }
 
 extension SetHouseWorkCollectionView: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return selectedDetailHouseWork.count
+        return HouseWork.mockHouseWork.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -85,7 +84,7 @@ extension SetHouseWorkCollectionView: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
         
-        if isSelectedDetailHouseWork.contains(selectedDetailHouseWork[indexPath.item].name) {
+        if isSelectedDetailHouseWork.contains(HouseWork.mockHouseWork[indexPath.item].name) {
             cell.houseWorkLabel.textColor = .blue
         }
         
@@ -94,7 +93,8 @@ extension SetHouseWorkCollectionView: UICollectionViewDataSource {
             collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .init())
         }
         
-        cell.houseWorkLabel.text = selectedDetailHouseWork[indexPath.row].name
+        cell.houseWorkLabel.text = HouseWork.mockHouseWork[indexPath.row].name
+        cell.timeLabel.text = HouseWork.mockHouseWork[indexPath.row].time
         
         cell.deleteButton.tag = indexPath.item
         cell.deleteButton.addTarget(self, action: #selector(didTappedDeleteButton(sender:)), for: .touchUpInside)
@@ -106,18 +106,18 @@ extension SetHouseWorkCollectionView: UICollectionViewDataSource {
 extension SetHouseWorkCollectionView {
     @objc func didTappedDeleteButton(sender : UIButton) {
         collectionView.deleteItems(at: [IndexPath.init(item: sender.tag, section: 0)])
-        isSelectedDetailHouseWork.removeAll(where: { $0 == selectedDetailHouseWork[sender.tag].name })
-        selectedDetailHouseWork.remove(at: sender.tag)
+        isSelectedDetailHouseWork.removeAll(where: { $0 == HouseWork.mockHouseWork[sender.tag].name })
         HouseWork.mockHouseWork.remove(at: sender.tag)
+        didDeleteHouseWork?(sender.tag)
         
-        print(HouseWork.mockHouseWork)
-                
-        if selectedDetailHouseWork.isEmpty {
+        if HouseWork.mockHouseWork.isEmpty {
             // FIXME: - 이전 페이지로 이동
         }
         
-        if selectedIndex > sender.tag || (selectedIndex == sender.tag && sender.tag == selectedDetailHouseWork.endIndex) {
+        if selectedIndex > sender.tag || (selectedIndex == sender.tag && sender.tag == HouseWork.mockHouseWork.endIndex) {
             selectedIndex -= 1
+        } else if sender.tag == selectedIndex {
+            isSelectedDetailHouseWork.append(HouseWork.mockHouseWork[sender.tag].name)
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SetHouseWorkCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SetHouseWorkCollectionView.swift
@@ -18,9 +18,8 @@ final class SetHouseWorkCollectionView: BaseUIView {
     }
     
     // FIXME: - SelectHouseWorkVC에서 선택한 집안일 목록 연결
-    private var selectedDetailHouseWork = ["창 청소", "거실 청소", "물건 정리정돈", "환기 시키기", "빨래 돌리기", "빨래 개기", "세탁기 청소"]
-    
-    lazy var isSelectedDetailHouseWork = [selectedDetailHouseWork[selectedIndex]]
+    private var selectedDetailHouseWork = HouseWork.mockHouseWork
+    lazy var isSelectedDetailHouseWork = [selectedDetailHouseWork[selectedIndex].name]
     
     private enum Size {
         static let collectionHorizontalSpacing: CGFloat = 24
@@ -68,7 +67,7 @@ final class SetHouseWorkCollectionView: BaseUIView {
 extension SetHouseWorkCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         selectedIndex = indexPath.item
-        isSelectedDetailHouseWork.append(selectedDetailHouseWork[selectedIndex])
+        isSelectedDetailHouseWork.append(selectedDetailHouseWork[selectedIndex].name)
     }
 }
 
@@ -83,7 +82,7 @@ extension SetHouseWorkCollectionView: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
         
-        if isSelectedDetailHouseWork.contains(selectedDetailHouseWork[indexPath.item]) {
+        if isSelectedDetailHouseWork.contains(selectedDetailHouseWork[indexPath.item].name) {
             cell.houseWorkLabel.textColor = .blue
         }
         
@@ -92,7 +91,7 @@ extension SetHouseWorkCollectionView: UICollectionViewDataSource {
             collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .init())
         }
         
-        cell.houseWorkLabel.text = selectedDetailHouseWork[indexPath.row]
+        cell.houseWorkLabel.text = selectedDetailHouseWork[indexPath.row].name
         
         cell.deleteButton.tag = indexPath.item
         cell.deleteButton.addTarget(self, action: #selector(didTappedDeleteButton(sender:)), for: .touchUpInside)
@@ -104,7 +103,7 @@ extension SetHouseWorkCollectionView: UICollectionViewDataSource {
 extension SetHouseWorkCollectionView {
     @objc func didTappedDeleteButton(sender : UIButton) {
         collectionView.deleteItems(at: [IndexPath.init(item: sender.tag, section: 0)])
-        isSelectedDetailHouseWork.removeAll(where: { $0 == selectedDetailHouseWork[sender.tag] })
+        isSelectedDetailHouseWork.removeAll(where: { $0 == selectedDetailHouseWork[sender.tag].name })
         selectedDetailHouseWork.remove(at: sender.tag)
                 
         if selectedDetailHouseWork.isEmpty {

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SetHouseWorkCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SetHouseWorkCollectionView.swift
@@ -11,6 +11,8 @@ import SnapKit
 
 final class SetHouseWorkCollectionView: BaseUIView {
     
+    var didTappedHouseWork: ((Int) -> ())?
+    
     var selectedIndex: Int = 0 {
         didSet {
             collectionView.reloadData()
@@ -68,6 +70,7 @@ extension SetHouseWorkCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         selectedIndex = indexPath.item
         isSelectedDetailHouseWork.append(selectedDetailHouseWork[selectedIndex].name)
+        didTappedHouseWork?(selectedIndex)
     }
 }
 
@@ -105,6 +108,9 @@ extension SetHouseWorkCollectionView {
         collectionView.deleteItems(at: [IndexPath.init(item: sender.tag, section: 0)])
         isSelectedDetailHouseWork.removeAll(where: { $0 == selectedDetailHouseWork[sender.tag].name })
         selectedDetailHouseWork.remove(at: sender.tag)
+        HouseWork.mockHouseWork.remove(at: sender.tag)
+        
+        print(HouseWork.mockHouseWork)
                 
         if selectedDetailHouseWork.isEmpty {
             // FIXME: - 이전 페이지로 이동

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SetHouseWorkCollectionViewCell.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SetHouseWorkCollectionViewCell.swift
@@ -25,7 +25,6 @@ final class SetHouseWorkCollectionViewCell: BaseCollectionViewCell {
     
     let timeLabel: UILabel = {
         let label = UILabel()
-        label.setTextWithLineHeight(text: TextLiteral.setHouseWorkCollectionViewCellDefaultTimeLabel, lineHeight: 18)
         label.textColor = .gray700
         label.font = .caption1
         label.numberOfLines = 0
@@ -47,18 +46,17 @@ final class SetHouseWorkCollectionViewCell: BaseCollectionViewCell {
     // MARK: - life cycle
     
     override func render() {
-        self.addSubview(timeLabel)
+        self.addSubviews(timeLabel, deleteButton, houseWorkLabel)
+        
         timeLabel.snp.makeConstraints {
             $0.top.leading.equalToSuperview().inset(12)
         }
         
-        self.addSubview(deleteButton)
         deleteButton.snp.makeConstraints {
             $0.top.trailing.equalToSuperview().inset(10)
             $0.width.height.equalTo(16)
         }
         
-        self.addSubview(houseWorkLabel)
         houseWorkLabel.snp.makeConstraints {
             $0.bottom.leading.equalToSuperview().inset(12)
         }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SetHouseWorkCollectionViewCell.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/UIComponent/SetHouseWorkCollectionViewCell.swift
@@ -23,11 +23,12 @@ final class SetHouseWorkCollectionViewCell: BaseCollectionViewCell {
     
     // MARK: - property
     
-    private let timeLabel: UILabel = {
+    let timeLabel: UILabel = {
         let label = UILabel()
         label.setTextWithLineHeight(text: TextLiteral.setHouseWorkCollectionViewCellDefaultTimeLabel, lineHeight: 18)
         label.textColor = .gray700
         label.font = .caption1
+        label.numberOfLines = 0
         return label
     }()
     lazy var deleteButton: UIButton = {


### PR DESCRIPTION
## 📣 Related Issue
- close #70 


## 👩‍💻 Contents & Screenshot
https://user-images.githubusercontent.com/81340603/216532073-c7011801-5bca-48e4-b638-c7baeeccb314.mp4

- 시간 설정 & 반복하기 Label 과 Switch 생성
- 시간 설정
   - DatePicker 생성
- 반복하기
   - 반복 주기 설정 (`RepeatCycleView` & `RepeatCycleMenu`)
   - 반복 요일 설정(`RepeatCycleCollectionView`)
   - 반복 정보 라벨(`RepeatCycleDayLabel`) 생성
- HouseWork Model 생성 및 Mockdata 연결
- 집안일 수정/삭제에 따른 Mockdata 수정/삭제
- 집안일 포커스 변경에 따른 담당자/시간설정/반복하기 업데이트 로직 구현
- 집안일 설정 화면과 관련된 화면 코드 정리


## 📌 Review Point
먼저 죄송합니다,,, 사이즈가 너무 큰 피알을 올려버렸네요,,, 나름 크기 줄인다고 3번에 나눠서 구현했는데도
이번 PR에서 UI 외에도 구현해야 할 로직이 너무 많았어요 ㅠㅠㅠ 한 번 시작하니 중간에 멈추면 다시 할 자신도 없어서 일단 다 해버렸습니다,,

1. HouseWork 모델 생성
   상단에 있는 집안일 CollectionView에서 어떤 Cell을 터치(포커스)하냐에 따라서 아래 있는 담당자 & 시간 & 반복 컴포넌트가 달라져야 하는 로직을 구현하기 위해 임의로 모델을 만들었습니다. Swagger 를 참고해서 제작했지만 타입이나 변수 이름이 완벽하게 일치하지 않습니다. UI 구현 단계에서 가장 적합한 형식으로 만들어 두었습니다. api 연결할 때 수정이 필요할듯 해요.
3. 준혁님께서 만들어 주신 addSubViews로 컴포넌트 올려봤습니다! 그래서 이전 PR(담당자)에서 개발한 부분이 일부 수정되었어요!
4. 반복주기를 enum으로 선언해두었습니다. `RepeatType`
   enum 안에는 week(매주), month(매달) type 이 존재합니다.
5. 담당자 부분부터 Scroll 가능하도록 ScrollView에 올려두었습니다. 시간 설정과 반복하기 토글이 모두 켜졌을 때만 Scroll 될거에요!
6. 이번에는 반복되는 코드가 많아서 VC 내 private 메소드를 많이 만들어봤습니다. 어떤 일을 하는 메소드인지를 다른 사람이 봐도 이해될 수 있도록 하고 싶었는데 메소드가 너무 많아서 오히려 어지러워진 게 아닌지 걱정이네요.. 준혁님께서 읽어보시고 의견 남겨주시면 감사하겠습니다..!

이외 설명이 필요한 부분은 코드에 직접 코멘트 남길게요! 

## 🔓 Next Step
- 집안일 직접 입력 뷰

## 📬 Reference
[배열을 문자열로 조인하기]
https://dmsitter.tistory.com/136

[CollectionView에서 Cell 사이 간격 지정하기]
https://88yhtserof.tistory.com/50

