### PR TITLE
[ADD] 집안일 직접 입력_반복하기 & 마무리

### DIFF
--- a/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
+++ b/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
@@ -13,6 +13,15 @@ enum TextLiteral {
     
     static let doneButtonText: String = "입력 완료"
     static let textFieldDisableSignLabel: String = "&,!,#,@,^와 같은 특수문자는 입력하실 수 없어요."
+    static let setManagerToastLabel = "집안일 담당자를 지정해주세요."
+    static let setTimeLabel = "시간설정"
+    static let setRepeatLabel = "반복하기"
+    static let houseWorkDoneButtonText = "집안일 추가 완료"
+    static let everyWeekText = "매주 "
+    static let weekText = "요일"
+    static let everyMonthText = "매달 "
+    static let dayText = "일"
+    static let repeatText = "에 반복해요"
     
     // MARK: - OnboardingNameViewController
     
@@ -147,7 +156,6 @@ enum TextLiteral {
     // MARK: - SetHouseWorkCollectionViewCell
     
     static let setHouseWorkCollectionViewCellDefaultTimeLabel = "하루 종일"
-    static let setHouseWorkManagerToastLabel = "집안일 담당자를 지정해주세요."
     
     // MARK: - SelectManagerView
     
@@ -166,18 +174,6 @@ enum TextLiteral {
     // MARK: - RepeatCycleCollectionView
     
     static let repeatCycleCollectionViewDaysOfWeekList = ["0월", "1화", "2수", "3목", "4금", "5토", "6일"]
-    
-    // MARK: - SetHouseWorkViewController
-    
-    static let setHouseWorkViewControllerSetTimeLabel = "시간설정"
-    static let setHouseWorkViewControllerSetRepeatLabel = "반복하기"
-    static let setHouseWorkViewControllerDoneButtonText = "집안일 추가 완료"
-    static let setHouseWorkViewControllerEveryWeek = "매주 "
-    static let setHouseWorkViewControllerWeek = "요일"
-    static let setHouseWorkViewControllerEveryMonth = "매달 "
-    static let setHouseWorkViewControllerDay = "일"
-    static let setHouseWorkViewControllerRepeat = "에 반복해요"
-    
     
     // MARK: - WriteHouseWorkViewController
     

--- a/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
+++ b/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let rootViewController = UINavigationController(rootViewController: WriteHouseWorkViewController())
+        let rootViewController = UINavigationController(rootViewController: HomeViewController())
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
     }

--- a/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
+++ b/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let rootViewController = UINavigationController(rootViewController: HomeViewController())
+        let rootViewController = UINavigationController(rootViewController: WriteHouseWorkViewController())
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
     }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -42,7 +42,7 @@ final class SetHouseWorkViewController: BaseViewController {
     }()
     private let managerToastLabel: UILabel = {
         let label = UILabel()
-        label.text = TextLiteral.setHouseWorkManagerToastLabel
+        label.text = TextLiteral.setManagerToastLabel
         label.textColor = .white
         label.font = .title2
         label.backgroundColor = .gray700
@@ -54,7 +54,7 @@ final class SetHouseWorkViewController: BaseViewController {
     }()
     private let setTimeLabel: UILabel = {
         let label = UILabel()
-        label.setTextWithLineHeight(text: TextLiteral.setHouseWorkViewControllerSetTimeLabel, lineHeight: 22)
+        label.setTextWithLineHeight(text: TextLiteral.setTimeLabel, lineHeight: 22)
         label.textColor = .gray600
         label.font = .title1
         return label
@@ -89,7 +89,7 @@ final class SetHouseWorkViewController: BaseViewController {
     }()
     private let setRepeatLabel: UILabel = {
         let label = UILabel()
-        label.setTextWithLineHeight(text: TextLiteral.setHouseWorkViewControllerSetRepeatLabel, lineHeight: 22)
+        label.setTextWithLineHeight(text: TextLiteral.setRepeatLabel, lineHeight: 22)
         label.textColor = .gray600
         label.font = .title1
         return label
@@ -124,7 +124,7 @@ final class SetHouseWorkViewController: BaseViewController {
     }()
     private let doneButton: MainButton = {
         let button = MainButton()
-        button.title = TextLiteral.setHouseWorkViewControllerDoneButtonText
+        button.title = TextLiteral.houseWorkDoneButtonText
         button.isDisabled = false
         return button
     }()
@@ -508,11 +508,11 @@ final class SetHouseWorkViewController: BaseViewController {
     private func updateRepeatCycleDayLabel(_ type: RepeatType, _ repeatDay: String) {
         switch type {
         case .week:
-            repeatCycleDayLabel.text = TextLiteral.setHouseWorkViewControllerEveryWeek + repeatDay + TextLiteral.setHouseWorkViewControllerWeek + TextLiteral.setHouseWorkViewControllerRepeat
-            repeatCycleDayLabel.applyColor(to: repeatDay + TextLiteral.setHouseWorkViewControllerWeek, with: .positive20)
+            repeatCycleDayLabel.text = TextLiteral.everyWeekText + repeatDay + TextLiteral.weekText + TextLiteral.repeatText
+            repeatCycleDayLabel.applyColor(to: repeatDay + TextLiteral.weekText, with: .positive20)
         case .month:
-            repeatCycleDayLabel.text = TextLiteral.setHouseWorkViewControllerEveryMonth + repeatDay + TextLiteral.setHouseWorkViewControllerDay + TextLiteral.setHouseWorkViewControllerRepeat
-            repeatCycleDayLabel.applyColor(to: repeatDay + TextLiteral.setHouseWorkViewControllerDay, with: .positive20)
+            repeatCycleDayLabel.text = TextLiteral.everyMonthText + repeatDay + TextLiteral.dayText + TextLiteral.repeatText
+            repeatCycleDayLabel.applyColor(to: repeatDay + TextLiteral.dayText, with: .positive20)
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SetHouseWork/SetHouseWorkViewController.swift
@@ -369,7 +369,7 @@ final class SetHouseWorkViewController: BaseViewController {
             repeatCycleDayLabel.snp.remakeConstraints {
                 $0.top.equalTo(repeatCycleCollectionView.snp.bottom).offset(16)
                 $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
-                $0.bottom.equalTo(0)
+                $0.bottom.equalToSuperview().inset(40)
             }
             HouseWork.mockHouseWork[selectedHouseWorkIndex].repeatCycle = RepeatType.week
             repeatCycleView.repeatCycleButtonLabel.text = RepeatType.week.rawValue

--- a/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
@@ -12,6 +12,7 @@ import SnapKit
 final class WriteHouseWorkViewController: BaseViewController {
     
     var houseWorkMaxLength = 16
+    var isCorrection: Bool = false
     
     // MARK: - property
     
@@ -149,6 +150,7 @@ final class WriteHouseWorkViewController: BaseViewController {
         super.viewDidLoad()
         setupNotificationCenter()
         setupDelegation()
+        setupCorrection()
         didTappedRepeatCycleMenuButton()
         didSelectDaysOfWeek()
         hidekeyboardWhenTappedAround()
@@ -291,6 +293,13 @@ final class WriteHouseWorkViewController: BaseViewController {
     private func setupNotificationCenter() {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    private func setupCorrection() {
+        if isCorrection {
+            // FIXME: - 집안일 정보 불러오는 api 연결 후 ui 업데이트
+            doneButton.title = "수정 완료"
+        }
     }
     
     @objc private func keyboardWillShow(notification: NSNotification) {

--- a/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
@@ -116,6 +116,14 @@ final class WriteHouseWorkViewController: BaseViewController {
         toggle.addAction(action, for: .touchUpInside)
         return toggle
     }()
+    private lazy var repeatCycleView: RepeatCycleView = {
+        let view = RepeatCycleView()
+        let action = UIAction { [weak self] _ in
+            self?.didTappedRepeatCycleButton()
+        }
+        view.repeatCycleButton.addAction(action, for: .touchUpInside)
+        return view
+    }()
     
     // MARK: - life cycle
     
@@ -128,7 +136,7 @@ final class WriteHouseWorkViewController: BaseViewController {
     override func render() {
         view.addSubviews(scrollView, selectManagerView, managerToastLabel)
         scrollView.addSubview(contentView)
-        contentView.addSubviews(writeHouseWorkCalendarView, houseWorkNameLabel, houseWorkNameTextField, houseWorkNameWarningLabel, getManagerView, setTimeLabel, setTimeToggle, timePicker, divider, setRepeatLabel, setRepeatToggle)
+        contentView.addSubviews(writeHouseWorkCalendarView, houseWorkNameLabel, houseWorkNameTextField, houseWorkNameWarningLabel, getManagerView, setTimeLabel, setTimeToggle, timePicker, divider, setRepeatLabel, setRepeatToggle, repeatCycleView)
         
         scrollView.snp.makeConstraints {
             $0.edges.equalToSuperview()
@@ -198,6 +206,12 @@ final class WriteHouseWorkViewController: BaseViewController {
             $0.centerY.equalTo(setRepeatLabel.snp.centerY)
             $0.trailing.equalToSuperview().inset(20)
             $0.bottom.equalTo(0)
+        }
+        
+        repeatCycleView.snp.makeConstraints {
+            $0.top.equalTo(setRepeatLabel.snp.bottom).offset(SizeLiteral.componentPadding)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.height.equalTo(0)
         }
         
         selectManagerView.snp.makeConstraints {
@@ -343,6 +357,10 @@ final class WriteHouseWorkViewController: BaseViewController {
     
     private func didTappedRepeatToggle() {
         print("토글토글")
+    }
+    
+    private func didTappedRepeatCycleButton() {
+        print("cycle button")
     }
 }
 

--- a/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
@@ -290,9 +290,7 @@ final class WriteHouseWorkViewController: BaseViewController {
             $0.height.equalTo(341)
         }
         
-        UIView.animate(withDuration: 0.4, delay: 0, options: .transitionCurlUp, animations: {
-            self.view.layoutIfNeeded()
-        }, completion: nil)
+        addAnimation()
         
         selectManagerView.selectManagerCollectionView.selectedManagerList = getManagerView.getManagerCollectionView.selectedMemberList
     }
@@ -302,9 +300,7 @@ final class WriteHouseWorkViewController: BaseViewController {
             $0.height.equalTo(0)
         }
         
-        UIView.animate(withDuration: 0.4, delay: 0, options: .transitionCurlDown, animations: {
-            self.view.layoutIfNeeded()
-        }, completion: nil)
+        addAnimation()
         
         selectManagerView.selectManagerCollectionView.selectedManagerList = getManagerView.getManagerCollectionView.selectedMemberList
     }
@@ -315,9 +311,7 @@ final class WriteHouseWorkViewController: BaseViewController {
                 $0.height.equalTo(0)
             }
             
-            UIView.animate(withDuration: 0.4, delay: 0, options: .transitionCurlDown, animations: {
-                self.view.layoutIfNeeded()
-            }, completion: nil)
+            addAnimation()
             
             getManagerView.getManagerCollectionView.selectedMemberList = selectManagerView.selectManagerCollectionView.selectedManagerList
         } else {
@@ -344,9 +338,7 @@ final class WriteHouseWorkViewController: BaseViewController {
                 $0.top.equalTo(setTimeLabel.snp.bottom).offset(8)
                 $0.height.equalTo(196.2)
             }
-            UIView.animate(withDuration: 0.4, delay: 0, options: .transitionCurlUp, animations: {
-                self.view.layoutIfNeeded()
-            }, completion: nil)
+            addAnimation()
         } else {
             timePicker.snp.updateConstraints {
                 $0.top.equalTo(setTimeLabel.snp.bottom)
@@ -356,11 +348,39 @@ final class WriteHouseWorkViewController: BaseViewController {
     }
     
     private func didTappedRepeatToggle() {
-        print("토글토글")
+        if setRepeatToggle.isOn {
+            openRepeatCycleView()
+        } else {
+            closeRepeatCycleView()
+        }
+        addAnimation()
     }
     
     private func didTappedRepeatCycleButton() {
         print("cycle button")
+    }
+    
+    private func openRepeatCycleView() {
+        repeatCycleView.snp.updateConstraints {
+            $0.height.equalTo(36)
+        }
+        repeatCycleView.repeatCycleLabel.isHidden = false
+        repeatCycleView.repeatCycleButton.isHidden = false
+        repeatCycleView.repeatCycleButtonLabel.text = RepeatType.week.rawValue
+    }
+    
+    private func closeRepeatCycleView() {
+        repeatCycleView.snp.updateConstraints {
+            $0.height.equalTo(0)
+        }
+        repeatCycleView.repeatCycleLabel.isHidden = true
+        repeatCycleView.repeatCycleButton.isHidden = true
+    }
+    
+    private func addAnimation() {
+        UIView.animate(withDuration: 0.4, delay: 0, options: .transitionCurlUp, animations: {
+            self.view.layoutIfNeeded()
+        }, completion: nil)
     }
 }
 

--- a/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
@@ -11,7 +11,7 @@ import SnapKit
 
 final class WriteHouseWorkViewController: BaseViewController {
     
-    var houseWorkMaxLength = 16
+    private let houseWorkMaxLength = 16
     var isCorrection: Bool = false
     
     // MARK: - property
@@ -416,7 +416,7 @@ final class WriteHouseWorkViewController: BaseViewController {
             repeatCycleDayLabel.snp.remakeConstraints {
                 $0.top.equalTo(repeatCycleCollectionView.snp.bottom).offset(16)
                 $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
-                $0.bottom.equalTo(0)
+                $0.bottom.equalToSuperview().inset(40)
             }
             repeatCycleView.repeatCycleLabel.isHidden = false
             repeatCycleView.repeatCycleButton.isHidden = false

--- a/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
@@ -98,6 +98,24 @@ final class WriteHouseWorkViewController: BaseViewController {
         view.backgroundColor = .gray100
         return view
     }()
+    private let setRepeatLabel: UILabel = {
+        let label = UILabel()
+        label.setTextWithLineHeight(text: TextLiteral.setHouseWorkViewControllerSetRepeatLabel, lineHeight: 22)
+        label.textColor = .gray600
+        label.font = .title1
+        return label
+    }()
+    private lazy var setRepeatToggle: UISwitch = {
+        let toggle = UISwitch()
+        toggle.isOn = false
+        toggle.onTintColor = .blue
+        toggle.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
+        let action = UIAction { [weak self] _ in
+            self?.didTappedRepeatToggle()
+        }
+        toggle.addAction(action, for: .touchUpInside)
+        return toggle
+    }()
     
     // MARK: - life cycle
     
@@ -110,7 +128,7 @@ final class WriteHouseWorkViewController: BaseViewController {
     override func render() {
         view.addSubviews(scrollView, selectManagerView, managerToastLabel)
         scrollView.addSubview(contentView)
-        contentView.addSubviews(writeHouseWorkCalendarView, houseWorkNameLabel, houseWorkNameTextField, houseWorkNameWarningLabel, getManagerView, setTimeLabel, setTimeToggle, timePicker, divider)
+        contentView.addSubviews(writeHouseWorkCalendarView, houseWorkNameLabel, houseWorkNameTextField, houseWorkNameWarningLabel, getManagerView, setTimeLabel, setTimeToggle, timePicker, divider, setRepeatLabel, setRepeatToggle)
         
         scrollView.snp.makeConstraints {
             $0.edges.equalToSuperview()
@@ -169,7 +187,16 @@ final class WriteHouseWorkViewController: BaseViewController {
             $0.top.equalTo(timePicker.snp.bottom).offset(SizeLiteral.componentPadding)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.height.equalTo(2)
-            // FIXME: - 하단에 컴포넌트 추가되면 삭제
+        }
+        
+        setRepeatLabel.snp.makeConstraints {
+            $0.top.equalTo(divider.snp.bottom).offset(SizeLiteral.componentPadding)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+        }
+        
+        setRepeatToggle.snp.makeConstraints {
+            $0.centerY.equalTo(setRepeatLabel.snp.centerY)
+            $0.trailing.equalToSuperview().inset(20)
             $0.bottom.equalTo(0)
         }
         
@@ -312,6 +339,10 @@ final class WriteHouseWorkViewController: BaseViewController {
                 $0.height.equalTo(0)
             }
         }
+    }
+    
+    private func didTappedRepeatToggle() {
+        print("토글토글")
     }
 }
 

--- a/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
@@ -404,12 +404,13 @@ final class WriteHouseWorkViewController: BaseViewController {
                 $0.top.equalTo(repeatCycleCollectionView.snp.bottom).offset(16)
                 $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             }
+            repeatCycleMenu.isHidden = true
         }
         addAnimation()
     }
     
     private func didTappedRepeatCycleButton() {
-        print("cycle button")
+        repeatCycleMenu.isHidden.toggle()
     }
     
     private func openRepeatCycleView() {

--- a/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
@@ -140,6 +140,7 @@ final class WriteHouseWorkViewController: BaseViewController {
         super.viewDidLoad()
         setupNotificationCenter()
         setupDelegation()
+        didTappedRepeatCycleMenuButton()
     }
     
     override func render() {
@@ -446,6 +447,26 @@ final class WriteHouseWorkViewController: BaseViewController {
         case .month:
             repeatCycleDayLabel.text = TextLiteral.setHouseWorkViewControllerEveryMonth + repeatDay + TextLiteral.setHouseWorkViewControllerDay + TextLiteral.setHouseWorkViewControllerRepeat
             repeatCycleDayLabel.applyColor(to: repeatDay + TextLiteral.setHouseWorkViewControllerDay, with: .positive20)
+        }
+    }
+    
+    private func didTappedRepeatCycleMenuButton() {
+        repeatCycleMenu.didTappedRepeatCycleMenuButton = { [weak self] repeatCycle in
+            switch repeatCycle {
+            case .week:
+                self?.repeatCycleCollectionView.snp.updateConstraints {
+                    $0.height.equalTo(40)
+                }
+                self?.updateRepeatCycleDayLabel(.week, Date().dayOfWeekToKoreanString)
+                self?.repeatCycleCollectionView.selectedDaysOfWeek = []
+            case .month:
+                self?.repeatCycleCollectionView.snp.updateConstraints {
+                    $0.height.equalTo(0)
+                }
+                self?.updateRepeatCycleDayLabel(.month, Date().singleDayToKoreanString)
+            }
+            self?.repeatCycleView.repeatCycleButtonLabel.text = repeatCycle.rawValue
+            self?.repeatCycleMenu.isHidden = true
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
@@ -93,6 +93,11 @@ final class WriteHouseWorkViewController: BaseViewController {
         picker.timeZone = .autoupdatingCurrent
         return picker
     }()
+    private let divider: UIView = {
+        let view = UIView()
+        view.backgroundColor = .gray100
+        return view
+    }()
     
     // MARK: - life cycle
     
@@ -105,7 +110,7 @@ final class WriteHouseWorkViewController: BaseViewController {
     override func render() {
         view.addSubviews(scrollView, selectManagerView, managerToastLabel)
         scrollView.addSubview(contentView)
-        contentView.addSubviews(writeHouseWorkCalendarView, houseWorkNameLabel, houseWorkNameTextField, houseWorkNameWarningLabel, getManagerView, setTimeLabel, setTimeToggle, timePicker)
+        contentView.addSubviews(writeHouseWorkCalendarView, houseWorkNameLabel, houseWorkNameTextField, houseWorkNameWarningLabel, getManagerView, setTimeLabel, setTimeToggle, timePicker, divider)
         
         scrollView.snp.makeConstraints {
             $0.edges.equalToSuperview()
@@ -158,6 +163,12 @@ final class WriteHouseWorkViewController: BaseViewController {
             $0.top.equalTo(setTimeLabel.snp.bottom)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.height.equalTo(0)
+        }
+        
+        divider.snp.makeConstraints {
+            $0.top.equalTo(timePicker.snp.bottom).offset(SizeLiteral.componentPadding)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.height.equalTo(2)
             // FIXME: - 하단에 컴포넌트 추가되면 삭제
             $0.bottom.equalTo(0)
         }

--- a/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
@@ -125,6 +125,13 @@ final class WriteHouseWorkViewController: BaseViewController {
         return view
     }()
     private let repeatCycleCollectionView = RepeatCycleCollectionView()
+    private lazy var repeatCycleDayLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .gray400
+        label.font = .body2
+        label.isHidden = true
+        return label
+    }()
     
     // MARK: - life cycle
     
@@ -137,7 +144,7 @@ final class WriteHouseWorkViewController: BaseViewController {
     override func render() {
         view.addSubviews(scrollView, selectManagerView, managerToastLabel)
         scrollView.addSubview(contentView)
-        contentView.addSubviews(writeHouseWorkCalendarView, houseWorkNameLabel, houseWorkNameTextField, houseWorkNameWarningLabel, getManagerView, setTimeLabel, setTimeToggle, timePicker, divider, setRepeatLabel, setRepeatToggle, repeatCycleView, repeatCycleCollectionView)
+        contentView.addSubviews(writeHouseWorkCalendarView, houseWorkNameLabel, houseWorkNameTextField, houseWorkNameWarningLabel, getManagerView, setTimeLabel, setTimeToggle, timePicker, divider, setRepeatLabel, setRepeatToggle, repeatCycleView, repeatCycleCollectionView, repeatCycleDayLabel)
         
         scrollView.snp.makeConstraints {
             $0.edges.equalToSuperview()
@@ -219,6 +226,11 @@ final class WriteHouseWorkViewController: BaseViewController {
             $0.top.equalTo(repeatCycleView.snp.bottom).offset(8)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(0)
+        }
+        
+        repeatCycleDayLabel.snp.makeConstraints {
+            $0.top.equalTo(repeatCycleCollectionView.snp.bottom).offset(16)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         
         selectManagerView.snp.makeConstraints {
@@ -357,8 +369,33 @@ final class WriteHouseWorkViewController: BaseViewController {
     private func didTappedRepeatToggle() {
         if setRepeatToggle.isOn {
             openRepeatCycleView()
+            repeatCycleCollectionView.snp.updateConstraints {
+                $0.height.equalTo(40)
+            }
+            setRepeatToggle.snp.remakeConstraints {
+                $0.centerY.equalTo(setRepeatLabel.snp.centerY)
+                $0.trailing.equalToSuperview().inset(20)
+            }
+            repeatCycleDayLabel.snp.remakeConstraints {
+                $0.top.equalTo(repeatCycleCollectionView.snp.bottom).offset(16)
+                $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+                $0.bottom.equalTo(0)
+            }
+            updateRepeatCycleDayLabel(.week, Date().dayOfWeekToKoreanString)
         } else {
             closeRepeatCycleView()
+            repeatCycleCollectionView.snp.updateConstraints {
+                $0.height.equalTo(0)
+            }
+            setRepeatToggle.snp.remakeConstraints {
+                $0.centerY.equalTo(setRepeatLabel.snp.centerY)
+                $0.trailing.equalToSuperview().inset(20)
+                $0.bottom.equalTo(0)
+            }
+            repeatCycleDayLabel.snp.remakeConstraints {
+                $0.top.equalTo(repeatCycleCollectionView.snp.bottom).offset(16)
+                $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            }
         }
         addAnimation()
     }
@@ -371,9 +408,10 @@ final class WriteHouseWorkViewController: BaseViewController {
         repeatCycleView.snp.updateConstraints {
             $0.height.equalTo(36)
         }
+        repeatCycleView.repeatCycleButtonLabel.text = RepeatType.week.rawValue
         repeatCycleView.repeatCycleLabel.isHidden = false
         repeatCycleView.repeatCycleButton.isHidden = false
-        repeatCycleView.repeatCycleButtonLabel.text = RepeatType.week.rawValue
+        repeatCycleDayLabel.isHidden = false
     }
     
     private func closeRepeatCycleView() {
@@ -382,12 +420,24 @@ final class WriteHouseWorkViewController: BaseViewController {
         }
         repeatCycleView.repeatCycleLabel.isHidden = true
         repeatCycleView.repeatCycleButton.isHidden = true
+        repeatCycleDayLabel.isHidden = true
     }
     
     private func addAnimation() {
         UIView.animate(withDuration: 0.4, delay: 0, options: .transitionCurlUp, animations: {
             self.view.layoutIfNeeded()
         }, completion: nil)
+    }
+    
+    private func updateRepeatCycleDayLabel(_ type: RepeatType, _ repeatDay: String) {
+        switch type {
+        case .week:
+            repeatCycleDayLabel.text = TextLiteral.setHouseWorkViewControllerEveryWeek + repeatDay + TextLiteral.setHouseWorkViewControllerWeek + TextLiteral.setHouseWorkViewControllerRepeat
+            repeatCycleDayLabel.applyColor(to: repeatDay + TextLiteral.setHouseWorkViewControllerWeek, with: .positive20)
+        case .month:
+            repeatCycleDayLabel.text = TextLiteral.setHouseWorkViewControllerEveryMonth + repeatDay + TextLiteral.setHouseWorkViewControllerDay + TextLiteral.setHouseWorkViewControllerRepeat
+            repeatCycleDayLabel.applyColor(to: repeatDay + TextLiteral.setHouseWorkViewControllerDay, with: .positive20)
+        }
     }
 }
 

--- a/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
@@ -125,6 +125,7 @@ final class WriteHouseWorkViewController: BaseViewController {
         return view
     }()
     private let repeatCycleCollectionView = RepeatCycleCollectionView()
+    private let repeatCycleMenu = RepeatCycleMenu()
     private lazy var repeatCycleDayLabel: UILabel = {
         let label = UILabel()
         label.textColor = .gray400
@@ -144,7 +145,7 @@ final class WriteHouseWorkViewController: BaseViewController {
     override func render() {
         view.addSubviews(scrollView, selectManagerView, managerToastLabel)
         scrollView.addSubview(contentView)
-        contentView.addSubviews(writeHouseWorkCalendarView, houseWorkNameLabel, houseWorkNameTextField, houseWorkNameWarningLabel, getManagerView, setTimeLabel, setTimeToggle, timePicker, divider, setRepeatLabel, setRepeatToggle, repeatCycleView, repeatCycleCollectionView, repeatCycleDayLabel)
+        contentView.addSubviews(writeHouseWorkCalendarView, houseWorkNameLabel, houseWorkNameTextField, houseWorkNameWarningLabel, getManagerView, setTimeLabel, setTimeToggle, timePicker, divider, setRepeatLabel, setRepeatToggle, repeatCycleView, repeatCycleCollectionView, repeatCycleMenu, repeatCycleDayLabel)
         
         scrollView.snp.makeConstraints {
             $0.edges.equalToSuperview()
@@ -226,6 +227,13 @@ final class WriteHouseWorkViewController: BaseViewController {
             $0.top.equalTo(repeatCycleView.snp.bottom).offset(8)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(0)
+        }
+        
+        repeatCycleMenu.snp.makeConstraints {
+            $0.top.equalTo(repeatCycleView.snp.bottom)
+            $0.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.width.equalTo(98)
+            $0.height.equalTo(76)
         }
         
         repeatCycleDayLabel.snp.makeConstraints {

--- a/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
@@ -137,6 +137,12 @@ final class WriteHouseWorkViewController: BaseViewController {
         label.isHidden = true
         return label
     }()
+    private let doneButton: MainButton = {
+        let button = MainButton()
+        button.title = TextLiteral.setHouseWorkViewControllerDoneButtonText
+        button.isDisabled = false
+        return button
+    }()
     
     // MARK: - life cycle
     
@@ -146,15 +152,22 @@ final class WriteHouseWorkViewController: BaseViewController {
         setupDelegation()
         didTappedRepeatCycleMenuButton()
         didSelectDaysOfWeek()
+        hidekeyboardWhenTappedAround()
     }
     
     override func render() {
-        view.addSubviews(scrollView, selectManagerView, managerToastLabel)
+        view.addSubviews(scrollView, doneButton, selectManagerView, managerToastLabel)
         scrollView.addSubview(contentView)
         contentView.addSubviews(writeHouseWorkCalendarView, houseWorkNameLabel, houseWorkNameTextField, houseWorkNameWarningLabel, getManagerView, setTimeLabel, setTimeToggle, timePicker, divider, setRepeatLabel, setRepeatToggle, repeatCycleView, repeatCycleCollectionView, repeatCycleMenu, repeatCycleDayLabel)
         
+        doneButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(SizeLiteral.componentPadding)
+        }
+        
         scrollView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.top.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(doneButton.snp.top).inset(-16)
         }
         
         contentView.snp.makeConstraints {
@@ -162,7 +175,7 @@ final class WriteHouseWorkViewController: BaseViewController {
         }
         
         writeHouseWorkCalendarView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.top.equalToSuperview()
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(38)
         }
@@ -284,14 +297,14 @@ final class WriteHouseWorkViewController: BaseViewController {
     @objc private func keyboardWillShow(notification: NSNotification) {
         if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
             UIView.animate(withDuration: 0.2, animations: {
-                // FIXME: - button 이동 로직 추가
+                self.doneButton.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height + 36)
             })
         }
     }
     
     @objc private func keyboardWillHide(notification: NSNotification) {
         UIView.animate(withDuration: 0.2, animations: {
-            // FIXME: - button 이동 로직 추가
+            self.doneButton.transform = .identity
         })
     }
     
@@ -496,9 +509,5 @@ extension WriteHouseWorkViewController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true
-    }
-    
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        view.endEditing(true)
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
@@ -56,7 +56,7 @@ final class WriteHouseWorkViewController: BaseViewController {
     }()
     private let managerToastLabel: UILabel = {
         let label = UILabel()
-        label.text = TextLiteral.setHouseWorkManagerToastLabel
+        label.text = TextLiteral.setManagerToastLabel
         label.textColor = .white
         label.font = .title2
         label.backgroundColor = .gray700
@@ -68,8 +68,7 @@ final class WriteHouseWorkViewController: BaseViewController {
     }()
     private let setTimeLabel: UILabel = {
         let label = UILabel()
-        // FIXME: - 71 PR 머지되면 common textliteral 로 변경
-        label.setTextWithLineHeight(text: "시간설정", lineHeight: 22)
+        label.setTextWithLineHeight(text: TextLiteral.setTimeLabel, lineHeight: 22)
         label.textColor = .gray600
         label.font = .title1
         return label
@@ -104,7 +103,7 @@ final class WriteHouseWorkViewController: BaseViewController {
     }()
     private let setRepeatLabel: UILabel = {
         let label = UILabel()
-        label.setTextWithLineHeight(text: TextLiteral.setHouseWorkViewControllerSetRepeatLabel, lineHeight: 22)
+        label.setTextWithLineHeight(text: TextLiteral.setRepeatLabel, lineHeight: 22)
         label.textColor = .gray600
         label.font = .title1
         return label
@@ -139,7 +138,7 @@ final class WriteHouseWorkViewController: BaseViewController {
     }()
     private let doneButton: MainButton = {
         let button = MainButton()
-        button.title = TextLiteral.setHouseWorkViewControllerDoneButtonText
+        button.title = TextLiteral.houseWorkDoneButtonText
         button.isDisabled = false
         return button
     }()
@@ -456,11 +455,11 @@ final class WriteHouseWorkViewController: BaseViewController {
     private func updateRepeatCycleDayLabel(_ type: RepeatType, _ repeatDay: String) {
         switch type {
         case .week:
-            repeatCycleDayLabel.text = TextLiteral.setHouseWorkViewControllerEveryWeek + repeatDay + TextLiteral.setHouseWorkViewControllerWeek + TextLiteral.setHouseWorkViewControllerRepeat
-            repeatCycleDayLabel.applyColor(to: repeatDay + TextLiteral.setHouseWorkViewControllerWeek, with: .positive20)
+            repeatCycleDayLabel.text = TextLiteral.everyWeekText + repeatDay + TextLiteral.weekText + TextLiteral.repeatText
+            repeatCycleDayLabel.applyColor(to: repeatDay + TextLiteral.weekText, with: .positive20)
         case .month:
-            repeatCycleDayLabel.text = TextLiteral.setHouseWorkViewControllerEveryMonth + repeatDay + TextLiteral.setHouseWorkViewControllerDay + TextLiteral.setHouseWorkViewControllerRepeat
-            repeatCycleDayLabel.applyColor(to: repeatDay + TextLiteral.setHouseWorkViewControllerDay, with: .positive20)
+            repeatCycleDayLabel.text = TextLiteral.everyMonthText + repeatDay + TextLiteral.dayText + TextLiteral.repeatText
+            repeatCycleDayLabel.applyColor(to: repeatDay + TextLiteral.dayText, with: .positive20)
         }
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/WriteHouseWork/WriteHouseWorkViewController.swift
@@ -124,6 +124,7 @@ final class WriteHouseWorkViewController: BaseViewController {
         view.repeatCycleButton.addAction(action, for: .touchUpInside)
         return view
     }()
+    private let repeatCycleCollectionView = RepeatCycleCollectionView()
     
     // MARK: - life cycle
     
@@ -136,7 +137,7 @@ final class WriteHouseWorkViewController: BaseViewController {
     override func render() {
         view.addSubviews(scrollView, selectManagerView, managerToastLabel)
         scrollView.addSubview(contentView)
-        contentView.addSubviews(writeHouseWorkCalendarView, houseWorkNameLabel, houseWorkNameTextField, houseWorkNameWarningLabel, getManagerView, setTimeLabel, setTimeToggle, timePicker, divider, setRepeatLabel, setRepeatToggle, repeatCycleView)
+        contentView.addSubviews(writeHouseWorkCalendarView, houseWorkNameLabel, houseWorkNameTextField, houseWorkNameWarningLabel, getManagerView, setTimeLabel, setTimeToggle, timePicker, divider, setRepeatLabel, setRepeatToggle, repeatCycleView, repeatCycleCollectionView)
         
         scrollView.snp.makeConstraints {
             $0.edges.equalToSuperview()
@@ -211,6 +212,12 @@ final class WriteHouseWorkViewController: BaseViewController {
         repeatCycleView.snp.makeConstraints {
             $0.top.equalTo(setRepeatLabel.snp.bottom).offset(SizeLiteral.componentPadding)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.height.equalTo(0)
+        }
+        
+        repeatCycleCollectionView.snp.makeConstraints {
+            $0.top.equalTo(repeatCycleView.snp.bottom).offset(8)
+            $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(0)
         }
         


### PR DESCRIPTION
## 📣 Related Issue
- close #82 

## 👩‍💻 Contents & Screenshot
|<img src="https://user-images.githubusercontent.com/81340603/218438978-0c84a3e4-b32e-4d53-9e0d-fcc3ad8144da.png" width=200px />|<img src="https://user-images.githubusercontent.com/81340603/218438974-deec2d09-b8f9-4a3e-9d7f-6feb2ed614d6.png" width=200px />|<img src="https://user-images.githubusercontent.com/81340603/218438965-7217e465-db00-4b16-8fea-a2f702239842.png" width=200px />|<img src="https://user-images.githubusercontent.com/81340603/218438950-fea669c8-c846-43a6-8fc6-6103d6565032.png" width=200px />|
|:---:|:---:|:---:|:---:|
|<center>반복 - 매주</center>|<center>반복 - 매달</center>|<center>완료 버튼</center>|<center>스크롤</center>|

- 반복 `Label` & `Toggle` 추가
- `RepeatCycleView`(주기 확인) 추가
- `RepeatCollectionView`(요일 설정) 추가 
- `RepeatCycleMenu`(주기 설정) 추가
- 완료 `Button` 추가
- 유저 액션에 따른 `UI update logic` 추가 > Comment로 상세 내용 작성 예정

## 📌 Review Point
- 바뀐 코드가 꽤 있어 보이지만,,, SetHouseWork에서 만든 Component들을 그대로 가져다 사용해서 내용은 거의 동일합니다.
- CalendarView는 준혁님께서 하신 방식 그대로 사용할 예정입니다. 이를 위한 issue 와 pr 은 따로 팔 예정입니다.
- 집안일 직접 입력 화면(WriteHouseWork)은 집안일 수정(EditHouseWork) 과 내용 여부만 다를 뿐 UI는 동일해서 `isCorrection`이라는 boolean 값을 추가해서 새로운 화면 구현 대신 분기처리로 진행했습니다.
- 집안일 수정 화면에는 삭제 기능이 필요한데 피그마에서 어떤 버튼을 눌러야 삭제되는지 확인할 수 없어서 가혜님께 답변 받으면 추가할 예정입니다. (아마 api 연결 단계에서 슬쩍 진행하지 않을까 싶어요)


## 🔓 Next Step
- SelectHouseWork & SetHouseWork & WriteHouseWork 에서 사용하는 Calendar 추가 PR
- 프로필 설정(SettingProfile) 마무리
