### PR TITLE
[ADD] teams - 팀 생성 API 연결

### DIFF
--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		52FFDFB528FBF96900DE1AE8 /* HouseInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52FFDFB428FBF96900DE1AE8 /* HouseInfoViewController.swift */; };
 		5A8030822990D902005C7909 /* SettingHomeRuleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8030812990D902005C7909 /* SettingHomeRuleViewController.swift */; };
 		5A80308C29925146005C7909 /* SettingHomeRuleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A80308B29925146005C7909 /* SettingHomeRuleTableViewCell.swift */; };
+		5A8400F029C9B75A00C569E9 /* AddTeamResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8400EF29C9B75A00C569E9 /* AddTeamResponse.swift */; };
 		5A99A2DB29A8C3F3006FE9B2 /* BaseTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A99A2DA29A8C3F3006FE9B2 /* BaseTargetType.swift */; };
 		5A99A2DD29A8C42A006FE9B2 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A99A2DC29A8C42A006FE9B2 /* NetworkService.swift */; };
 		5A99A2DF29A8C45D006FE9B2 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A99A2DE29A8C45D006FE9B2 /* NetworkResult.swift */; };
@@ -233,6 +234,7 @@
 		52FFDFB428FBF96900DE1AE8 /* HouseInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HouseInfoViewController.swift; sourceTree = "<group>"; };
 		5A8030812990D902005C7909 /* SettingHomeRuleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingHomeRuleViewController.swift; sourceTree = "<group>"; };
 		5A80308B29925146005C7909 /* SettingHomeRuleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingHomeRuleTableViewCell.swift; sourceTree = "<group>"; };
+		5A8400EF29C9B75A00C569E9 /* AddTeamResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTeamResponse.swift; sourceTree = "<group>"; };
 		5A99A2DA29A8C3F3006FE9B2 /* BaseTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTargetType.swift; sourceTree = "<group>"; };
 		5A99A2DC29A8C42A006FE9B2 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		5A99A2DE29A8C45D006FE9B2 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
@@ -649,6 +651,7 @@
 			isa = PBXGroup;
 			children = (
 				52A53DC829B06DF200C4BB4C /* TeamInfoResponse.swift */,
+				5A8400EF29C9B75A00C569E9 /* AddTeamResponse.swift */,
 			);
 			path = Teams;
 			sourceTree = "<group>";
@@ -1200,6 +1203,7 @@
 				52EBF04B28EC29200062EB41 /* TextField.swift in Sources */,
 				39FABBDC28DB35020053EFD2 /* HomeCalendarView.swift in Sources */,
 				52FFDFB228FA984200DE1AE8 /* EnterHouseViewController.swift in Sources */,
+				5A8400F029C9B75A00C569E9 /* AddTeamResponse.swift in Sources */,
 				5204AABF2950BE43002FB6CA /* SettingInquiryCellView.swift in Sources */,
 				39EEF66F28CBB5A600437654 /* NSObject+Extension.swift in Sources */,
 				52E4C08E297D06F5002AC755 /* SelectManagerCollectionView.swift in Sources */,

--- a/fairer-iOS/fairer-iOS/Network/DTO/Teams/AddTeamResponse.swift
+++ b/fairer-iOS/fairer-iOS/Network/DTO/Teams/AddTeamResponse.swift
@@ -1,0 +1,11 @@
+//
+//  AddTeamResponse.swift
+//  fairer-iOS
+//
+//  Created by 김규철 on 2023/03/21.
+//
+
+struct AddTeamResponse: Codable {
+    let inviteCode: String
+    let teamId: Int
+}

--- a/fairer-iOS/fairer-iOS/Network/Router/TeamsRouter.swift
+++ b/fairer-iOS/fairer-iOS/Network/Router/TeamsRouter.swift
@@ -11,6 +11,7 @@ import Moya
 
 enum TeamsRouter {
     case getTeamInfo
+    case postAddTeam(teamName: String)
 }
 
 extension TeamsRouter: BaseTargetType {
@@ -18,6 +19,8 @@ extension TeamsRouter: BaseTargetType {
         switch self {
         case .getTeamInfo:
             return URLConstant.teams + "/my"
+        case .postAddTeam:
+            return URLConstant.teams
         }
     }
     
@@ -25,6 +28,8 @@ extension TeamsRouter: BaseTargetType {
         switch self {
         case .getTeamInfo:
             return .get
+        case .postAddTeam:
+            return .post
         }
     }
     
@@ -32,6 +37,8 @@ extension TeamsRouter: BaseTargetType {
         switch self {
         case .getTeamInfo:
             return .requestPlain
+        case .postAddTeam(let teamName):
+            return .requestParameters(parameters: ["teamName": teamName], encoding: JSONEncoding.default)
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/Group/HouseInviteCode/ViewController/HouseInviteCodeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/HouseInviteCode/ViewController/HouseInviteCodeViewController.swift
@@ -12,9 +12,19 @@ import SnapKit
 final class HouseInviteCodeViewController: BaseViewController {
     
     // FIXME: - 사용자 지정 하우스 이름, 서버에서 받은 초대코드, 코드 유효 시간으로 변경
-    let houseName: String = "즐거운 우리집"
-    let inviteCode: String = "4D1AGE9HE362"
+    var houseName: String
+    var inviteCode: String
     let validTime: Date = Calendar.current.date(byAdding: .hour, value: +1, to: Date())!
+    
+    init(houseName: String, inviteCode: String) {
+        self.houseName = houseName
+        self.inviteCode = inviteCode
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     // MARK: - property
     

--- a/fairer-iOS/fairer-iOS/Screens/Group/HouseMakeName/HouseMakeNameViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/HouseMakeName/HouseMakeNameViewController.swift
@@ -103,12 +103,19 @@ final class HouseMakeNameViewController: BaseViewController {
     }
     
     @objc private func didTapDoneButton() {
-        if houseNameTextField.text!.hasCharacters() {
+        guard let text = houseNameTextField.text else { return }
+        
+        if text.hasCharacters() {
             houseNameTextField.layer.borderWidth = 0
             disableLabel.isHidden = true
             
-            // TODO: - userdefault에 하우스 이름 저장
-            
+            postAddTeam(teamName: text) { [weak self] result in
+                let inviteCode = result.inviteCode
+                let houseInviteCodeView = HouseInviteCodeViewController(houseName: text, inviteCode: inviteCode)
+                
+                self?.navigationController?.pushViewController(houseInviteCodeView, animated: true)
+            }
+
         } else {
             houseNameTextField.layer.borderWidth = 1
             houseNameTextField.layer.borderColor = UIColor.negative20.cgColor
@@ -159,5 +166,21 @@ extension HouseMakeNameViewController : UITextFieldDelegate {
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         houseNameTextField.layer.borderWidth = 0
         view.endEditing(true)
+    }
+}
+
+extension HouseMakeNameViewController {
+    private func postAddTeam(teamName: String, completion: @escaping (AddTeamResponse) -> Void) {
+        NetworkService.shared.teams.postAddTeam(teamName: teamName) { result in
+            switch result {
+            case .success(let response):
+                guard let addPostTeamData = response as? AddTeamResponse else { return }
+                completion(addPostTeamData)
+            case .requestErr(let error):
+                dump(error)
+            default:
+                print("server error")
+            }
+        }
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #115 

## 👩‍💻 Contents & Screenshot
<!-- 작업 내용과 이미지를 첨부해주세요. -->

![Simulator Screen Recording - iPhone 13 mini - 2023-03-21 at 21 37 54](https://user-images.githubusercontent.com/25146374/226608165-3f9fddac-52e4-49eb-90e8-fb30fc58dd2b.gif)

- AddTeamResponse 생성
-  postAddTeamRouter, postAddTeamAPI 구현
- HouseMakeNameView에 postAddTeamAPI 연결

## 📌 Review Point
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->

 테스트 하시기 위해선, 스웨거에서 팀 나가기를 한번 진행 해 주세요.

<img width="545" alt="스크린샷 2023-03-21 오후 9 42 28" src="https://user-images.githubusercontent.com/25146374/226609210-4522bc2a-7d50-41f4-a525-4fd0ba576f7e.png">

- text 강제 언래핑을 변경했습니다.

HouseMakeNameView에서 입력 완료 버튼을 눌렀을 때 뷰가 Push 되면서 팀 이름(houseNameTextField.text)과 post 받은 inviteCode를 함께 넘겨줘야 해서 HouseInviteCodeView의 ihouseName, inviteCode을 init으로 초기화하여 받아왔습니다.

## 🧐 Question
<!-- PR 과정에서 생긴 질문을 적어주세요. -->

- init을 사용하다보니 의존성(DI)에 대해서도 공부가 더 필요하다는 걸 알게되었습니다..

## 🔓 Next Step
<!-- 다음으로 할 일을 적어주세요. -->
-  팀 참가 API

