### PR TITLE
[ADD] teams - 팀 나가기 API 연결

### DIFF
--- a/fairer-iOS/fairer-iOS/Network/API/TeamsAPI.swift
+++ b/fairer-iOS/fairer-iOS/Network/API/TeamsAPI.swift
@@ -18,6 +18,7 @@ final class TeamsAPI {
         case postAddTeam
         case postJoinTeam
         case patchTeamInfo
+        case postLeaveTeam
     }
     
     func getTeamInfo(completion: @escaping (NetworkResult<Any>) -> Void) {
@@ -75,6 +76,20 @@ final class TeamsAPI {
             }
         }
     }
+    
+    func postLeaveTeam(completion: @escaping (NetworkResult<Any>) -> Void) {
+        teamsProvider.request(.postLeaveTeam) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = self.judgeStatus(by: statusCode, data, responseData: .postLeaveTeam)
+                completion(networkResult)
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
 
     private func judgeStatus(by statusCode: Int, _ data: Data, responseData: ResponseData) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
@@ -82,7 +97,7 @@ final class TeamsAPI {
         switch statusCode {
         case 200..<300:
             switch responseData {
-            case .getTeamInfo, .postAddTeam, .postJoinTeam, .patchTeamInfo:
+            case .getTeamInfo, .postAddTeam, .postJoinTeam, .patchTeamInfo, .postLeaveTeam:
                 return isValidData(data: data, responseData: responseData)
             }
         case 400:
@@ -115,7 +130,7 @@ final class TeamsAPI {
                 return .pathErr
             }
             return .success(decodedData)
-        case .postJoinTeam, .patchTeamInfo:
+        case .postJoinTeam, .patchTeamInfo, .postLeaveTeam:
             return .success(())
         }
     }

--- a/fairer-iOS/fairer-iOS/Network/Router/TeamsRouter.swift
+++ b/fairer-iOS/fairer-iOS/Network/Router/TeamsRouter.swift
@@ -14,6 +14,7 @@ enum TeamsRouter {
     case postAddTeam(teamName: String)
     case postJoinTeam(inviteCode: String)
     case patchTeamInfo(teamName: String)
+    case postLeaveTeam
 }
 
 extension TeamsRouter: BaseTargetType {
@@ -25,6 +26,8 @@ extension TeamsRouter: BaseTargetType {
             return URLConstant.teams
         case .postJoinTeam:
             return URLConstant.teams + "/join"
+        case .postLeaveTeam:
+            return URLConstant.teams + "/leave"
         }
     }
     
@@ -32,7 +35,7 @@ extension TeamsRouter: BaseTargetType {
         switch self {
         case .getTeamInfo:
             return .get
-        case .postAddTeam, .postJoinTeam:
+        case .postAddTeam, .postJoinTeam, .postLeaveTeam:
             return .post
         case .patchTeamInfo:
             return .patch
@@ -41,7 +44,7 @@ extension TeamsRouter: BaseTargetType {
     
     var task: Moya.Task {
         switch self {
-        case .getTeamInfo:
+        case .getTeamInfo, .postLeaveTeam:
             return .requestPlain
         case .postAddTeam(let teamName), .patchTeamInfo(let teamName):
             return .requestParameters(parameters: ["teamName": teamName], encoding: JSONEncoding.default)

--- a/fairer-iOS/fairer-iOS/Screens/Setting/ManageHouse/ManageHouseViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Setting/ManageHouse/ManageHouseViewController.swift
@@ -166,8 +166,10 @@ final class ManageHouseViewController: BaseViewController {
     }
     
     private func touchUpToLeaveHouse() {
-        // FIXME: - 하우스 나가기 api 연결
-        self.makeRequestAlert(title: TextLiteral.manageHouseViewControllerAlertTitle, message: TextLiteral.manageHouseViewControllerAlertMessage, okTitle: TextLiteral.manageHouseViewControllerAlertOkTitle, cancelTitle: TextLiteral.manageHouseViewControllerAlertCancelTitle, okAction: { _ in print("하우스에서 나가기") }, cancelAction: nil, completion: nil)
+        self.makeRequestAlert(title: TextLiteral.manageHouseViewControllerAlertTitle, message: TextLiteral.manageHouseViewControllerAlertMessage, okTitle: TextLiteral.manageHouseViewControllerAlertOkTitle, cancelTitle: TextLiteral.manageHouseViewControllerAlertCancelTitle, okAction: { [weak self] _ in
+            self?.postLeaveTeam()
+            
+        }, cancelAction: nil, completion: nil)
     }
 }
 
@@ -192,6 +194,25 @@ extension ManageHouseViewController: UITableViewDelegate, UITableViewDataSource 
         if indexPath.row == 0 {
             self.navigationController?.pushViewController(ChangeHouseNameViewController(), animated: true)
             tableView.deselectRow(at: indexPath, animated: true)
+        }
+    }
+}
+
+extension ManageHouseViewController {
+    func postLeaveTeam() {
+        NetworkService.shared.teams.postLeaveTeam { [weak self] result in
+            switch result {
+            case .success(_):
+                let pushVC = GroupMainViewController()
+                if let navigationController = self?.navigationController {
+                    navigationController.pushViewController(pushVC, animated: true)
+                    navigationController.setViewControllers([pushVC], animated: true)
+                }
+            case .requestErr(let error):
+                dump(error)
+            default:
+                print("server Error")
+            }
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/Setting/ManageHouse/ManageHouseViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Setting/ManageHouse/ManageHouseViewController.swift
@@ -205,7 +205,6 @@ extension ManageHouseViewController {
             case .success(_):
                 let pushVC = GroupMainViewController()
                 if let navigationController = self?.navigationController {
-                    navigationController.pushViewController(pushVC, animated: true)
                     navigationController.setViewControllers([pushVC], animated: true)
                 }
             case .requestErr(let error):


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #133 

## 👩‍💻 Contents & Screenshot
<!-- 작업 내용과 이미지를 첨부해주세요. -->

![Simulator Screen Recording - iPhone 13 mini - 2023-04-04 at 20 38 24](https://user-images.githubusercontent.com/25146374/229780387-89b29ac7-6bdd-4027-8741-2cd6abb7b500.gif)

- postLeaveTeam Router, postLeaveTeam API 추가
- 하우스 나가기 모달에서 나가기 선택 시 post와 동시에 GroupMainView로 push 되도록  구현하였습니다.
- 더불어 push와 함께 기존의 navigation Stack을 모두 제거하고 GroupMainView가 첫번째 navigation Stack이 되도록 하였습니다.

## 📌 Review Point
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->

- 팀 나가기를 테스트 하기 전에 팀 초대 API를 통해 참가 코드를 저장해두고, 팀 나가기를 진행해주세요. ( 이후 팀 참가를 위해 )
- GroupMainView에서 navigation Stack이 정상적으로 모두 제거되었는지 확인 하기 위해선 팀 나가기 실행 전 아래 코드를 GroupMainViewController에 추가해주세요.

```
    override func viewDidLoad() {
        super.viewDidLoad()
        if let navigationController = self.navigationController {
            for viewController in navigationController.viewControllers {
                print("남은 뷰컨은 : \(viewController)")
            }
        }
    }
```

## 🔓 Next Step
<!-- 다음으로 할 일을 적어주세요. -->
- GroupMainView에 빠진 멤버 이름 get API 연결

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
https://pooh-footprints.tistory.com/47
