### PR TITLE
[ADD] members - 내 정보 조회 API 구현 및 그룹 메인 뷰에 바인딩

### DIFF
--- a/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
+++ b/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
@@ -56,6 +56,7 @@ enum TextLiteral {
 
     // MARK: - GroupMainViewController
     
+    static let groupMainViewControllerHouseTitleLabel: String = "님!\n새로 하우스를 만들거나 참여해주세요."
     static let groupMainViewControllerHouseMakeLabel: String = "집안일 하우스 생성"
     static let groupMainViewControllerHouseMakeButtonText: String = "집안일 하우스 만들기"
     static let groupMainViewControllerHouseMakeInfoLabel: String = "개인 혹은 여러명이 집안일을 관리할 수 있는 하우스를\n만들 수 있습니다."

--- a/fairer-iOS/fairer-iOS/Network/API/MembersAPI.swift
+++ b/fairer-iOS/fairer-iOS/Network/API/MembersAPI.swift
@@ -4,5 +4,66 @@
 //
 //  Created by 홍준혁 on 2023/02/22.
 //
-
 import Foundation
+
+import Moya
+
+final class MembersAPI {
+    
+    private var membersProvider = MoyaProvider<MemberRouter>(plugins: [MoyaLoggerPlugin()])
+    
+    private enum ResponseData {
+        case getMemberInfo
+    }
+    
+    func getMemberInfo(completion: @escaping (NetworkResult<Any>) -> Void) {
+        membersProvider.request(.getmemberInfo) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = self.judgeStatus(by: statusCode, data, responseData: .getMemberInfo)
+                completion(networkResult)
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+    
+    private func judgeStatus(by statusCode: Int, _ data: Data, responseData: ResponseData) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+
+        switch statusCode {
+        case 200..<300:
+            switch responseData {
+            case .getMemberInfo:
+                return isValidData(data: data, responseData: responseData)
+            }
+        case 400:
+            guard let decodedData = try? decoder.decode(UserErrorResponse.self, from: data) else {
+                return .pathErr
+            }
+            return .requestErr(decodedData)
+        case 401..<500:
+            guard let decodedData = try? decoder.decode(ErrorResponse.self, from: data) else {
+                return .pathErr
+            }
+            return .requestErr(decodedData)
+        case 500:
+            return .serverErr
+        default:
+            return .networkFail
+        }
+    }
+    
+    private func isValidData(data: Data, responseData: ResponseData) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        switch responseData {
+        case .getMemberInfo:
+            guard let decodedData = try? decoder.decode(MemberResponse.self, from: data) else {
+                return .pathErr
+            }
+            return .success(decodedData)
+        }
+    }
+}

--- a/fairer-iOS/fairer-iOS/Network/Foundation/NetworkService.swift
+++ b/fairer-iOS/fairer-iOS/Network/Foundation/NetworkService.swift
@@ -18,7 +18,7 @@ final class NetworkService {
     
     let houseWorks = HouseWorksAPI()
 //
-//    let members = MembersAPI()
+    let members = MembersAPI()
 //
     let oauth = OauthAPI()
 //

--- a/fairer-iOS/fairer-iOS/Network/Router/MembersRouter.swift
+++ b/fairer-iOS/fairer-iOS/Network/Router/MembersRouter.swift
@@ -5,4 +5,32 @@
 //  Created by 홍준혁 on 2023/02/22.
 //
 
-import Foundation
+import Moya
+
+enum MemberRouter {
+    case getmemberInfo
+
+}
+
+extension MemberRouter: BaseTargetType {
+    var path: String {
+        switch self {
+        case .getmemberInfo:
+            return URLConstant.members + "/me"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getmemberInfo:
+            return .get
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .getmemberInfo:
+            return .requestPlain
+        }
+    }
+}

--- a/fairer-iOS/fairer-iOS/Screens/Group/GroupMain/GroupMainViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/GroupMain/GroupMainViewController.swift
@@ -10,20 +10,14 @@ import UIKit
 import SnapKit
 
 final class GroupMainViewController: BaseViewController {
-    
-    private var userName:String = String() {
-        didSet {
-            titleLabel.text = "안녕하세요. \(userName)님!\n새로 하우스를 만들거나 참여해주세요."
-            titleLabel.applyColor(to: userName, with: .blue)
-        }
-    }
+
     // MARK: - property
     
     private let backButton = BackButton()
     private var titleLabel: UILabel = {
         let label = UILabel()
-        label.text = "안녕하세요. 님!\n새로 하우스를 만들거나 참여해주세요."
         label.font = .h2
+        label.text = "안녕하세요. " + TextLiteral.groupMainViewControllerHouseTitleLabel
         label.textColor = .gray800
         label.numberOfLines = 0
         return label
@@ -79,10 +73,9 @@ final class GroupMainViewController: BaseViewController {
     
     // MARK: - life cycle
     
-    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        getMemberInfo()
+        bindGroupMemberInfo()
     }
     
     override func render() {
@@ -138,17 +131,26 @@ final class GroupMainViewController: BaseViewController {
             $0.height.equalTo(44)
         }
     }
+    
+    // MARK: - functions
+    
+    private func bindGroupMemberInfo() {
+        getMemberInfo { [weak self] data in
+            guard let userName = data.memberName else { return }
+
+            self?.titleLabel.text = "안녕하세요. " + userName + TextLiteral.groupMainViewControllerHouseTitleLabel
+            self?.titleLabel.applyColor(to: userName, with: .blue)
+        }
+    }
 }
 
 extension GroupMainViewController {
-    func getMemberInfo() {
-        NetworkService.shared.members.getMemberInfo { [weak self] result in
+    func getMemberInfo(completion: @escaping (MemberResponse) -> Void) {
+        NetworkService.shared.members.getMemberInfo { result in
             switch result {
             case .success(let response):
                 guard let memberData = response as? MemberResponse else { return }
-                if let memberName = memberData.memberName {
-                    self?.userName = memberName
-                }
+                completion(memberData)
             case .requestErr(let error):
                 dump(error)
             default:

--- a/fairer-iOS/fairer-iOS/Screens/Group/GroupMain/GroupMainViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/GroupMain/GroupMainViewController.swift
@@ -11,19 +11,21 @@ import SnapKit
 
 final class GroupMainViewController: BaseViewController {
     
-    let userName: String = "고가혜"
-    
+    private var userName:String = String() {
+        didSet {
+            titleLabel.text = "안녕하세요. \(userName)님!\n새로 하우스를 만들거나 참여해주세요."
+            titleLabel.applyColor(to: userName, with: .blue)
+        }
+    }
     // MARK: - property
     
     private let backButton = BackButton()
-    private lazy var titleLabel: UILabel = {
+    private var titleLabel: UILabel = {
         let label = UILabel()
-        label.text = "안녕하세요. \(userName)님!\n새로 하우스를 만들거나 참여해주세요."
+        label.text = "안녕하세요. 님!\n새로 하우스를 만들거나 참여해주세요."
         label.font = .h2
         label.textColor = .gray800
-        label.applyColor(to: userName, with: .blue)
         label.numberOfLines = 0
-        // TODO: - LoginView pull 받아서 lineheight extension 적용
         return label
     }()
     private let houseMakeLabel: UILabel = {
@@ -77,6 +79,12 @@ final class GroupMainViewController: BaseViewController {
     
     // MARK: - life cycle
     
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        getMemberInfo()
+    }
+    
     override func render() {
         view.addSubview(titleLabel)
         titleLabel.snp.makeConstraints {
@@ -128,6 +136,24 @@ final class GroupMainViewController: BaseViewController {
             $0.top.equalTo(houseEnterButton.snp.bottom).offset(8)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.height.equalTo(44)
+        }
+    }
+}
+
+extension GroupMainViewController {
+    func getMemberInfo() {
+        NetworkService.shared.members.getMemberInfo { [weak self] result in
+            switch result {
+            case .success(let response):
+                guard let memberData = response as? MemberResponse else { return }
+                if let memberName = memberData.memberName {
+                    self?.userName = memberName
+                }
+            case .requestErr(let error):
+                dump(error)
+            default:
+                print("server Error")
+            }
         }
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #135

## 👩‍💻 Contents & Screenshot
<!-- 작업 내용과 이미지를 첨부해주세요. -->

![Simulator Screen Shot - iPhone 13 mini - 2023-04-05 at 14 33 57](https://user-images.githubusercontent.com/25146374/229989944-06c8a8ae-3f2c-4f89-bb75-6be0c4ce435d.png)

- member 정보 조회 API를 생성하고 그룹메인 뷰에 연결했습니다.

## 🧐 Question
<!-- PR 과정에서 생긴 질문을 적어주세요. -->

didSet이나 DispatchQueue를 사용했을 때 서버 통신이 느린 점에 대한 질문
- 뷰가 만들어짐과 동시에 통신이 이루어져서 정보를 같이 가져 와야 하는데, 뷰가 만들어 진 후 서버 통신이 되어서 뭔가 통신 하는 부분이 한박자 느린 느낌이 듭니다. 공부가 필요하거나 이래서 비동기 프레임워크를 쓰나? 하는 생각이 듭니다. 다른 뷰도 마찬가지 일 거 같아요.

## 🔓 Next Step
<!-- 다음으로 할 일을 적어주세요. -->
- 멤버 API