### PR TITLE
[ADD] teams - 팀 초대(초대 코드 보기) API 연결

### DIFF
--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		5A99A2DD29A8C42A006FE9B2 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A99A2DC29A8C42A006FE9B2 /* NetworkService.swift */; };
 		5A99A2DF29A8C45D006FE9B2 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A99A2DE29A8C45D006FE9B2 /* NetworkResult.swift */; };
 		5A9BD08829C1ECBE00ADD3CC /* SettingHomeRuleHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9BD08729C1ECBE00ADD3CC /* SettingHomeRuleHeaderView.swift */; };
+		5AA510FD29DE6AF100C977EF /* InviteCodeInfoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA510FC29DE6AF100C977EF /* InviteCodeInfoResponse.swift */; };
 		5AB1B9C329D55FC300DCA8FE /* ToastPaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB1B9C229D55FC300DCA8FE /* ToastPaddingLabel.swift */; };
 		5AB8068629BEE842009EB243 /* UserErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8068529BEE842009EB243 /* UserErrorResponse.swift */; };
 		5ABB7FB229B48DED008D5C15 /* RulesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABB7FB129B48DED008D5C15 /* RulesResponse.swift */; };
@@ -276,6 +277,7 @@
 		5A99A2DC29A8C42A006FE9B2 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		5A99A2DE29A8C45D006FE9B2 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
 		5A9BD08729C1ECBE00ADD3CC /* SettingHomeRuleHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingHomeRuleHeaderView.swift; sourceTree = "<group>"; };
+		5AA510FC29DE6AF100C977EF /* InviteCodeInfoResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteCodeInfoResponse.swift; sourceTree = "<group>"; };
 		5AB1B9C229D55FC300DCA8FE /* ToastPaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastPaddingLabel.swift; sourceTree = "<group>"; };
 		5AB8068529BEE842009EB243 /* UserErrorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserErrorResponse.swift; sourceTree = "<group>"; };
 		5ABB7FB129B48DED008D5C15 /* RulesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RulesResponse.swift; path = "fairer-iOS/Network/DTO/Rules/RulesResponse.swift"; sourceTree = SOURCE_ROOT; };
@@ -713,6 +715,7 @@
 			children = (
 				52A53DC829B06DF200C4BB4C /* TeamInfoResponse.swift */,
 				5A8400EF29C9B75A00C569E9 /* AddTeamResponse.swift */,
+				5AA510FC29DE6AF100C977EF /* InviteCodeInfoResponse.swift */,
 			);
 			path = Teams;
 			sourceTree = "<group>";
@@ -1307,6 +1310,7 @@
 				5A8030822990D902005C7909 /* SettingHomeRuleViewController.swift in Sources */,
 				5205055128DCB63D00355055 /* LoginViewController.swift in Sources */,
 				5205054528D8624700355055 /* OnboardingProfileGroupCollectionView.swift in Sources */,
+				5AA510FD29DE6AF100C977EF /* InviteCodeInfoResponse.swift in Sources */,
 				5205053D28D7382900355055 /* UITextField+Extension.swift in Sources */,
 				52E442A528F16A6400706A74 /* InviteCodeButtonView.swift in Sources */,
 				522714E8297917C3006BADBC /* SetHouseWorkViewController.swift in Sources */,

--- a/fairer-iOS/fairer-iOS/Global/Extension/String+Extension.swift
+++ b/fairer-iOS/fairer-iOS/Global/Extension/String+Extension.swift
@@ -20,6 +20,21 @@ extension String {
         return formatter.date(from: self)
     }
     
+    var iso8601ToDay: Date? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        return formatter.date(from: self)
+    }
+    
+    var iso8601ToKoreanString: String? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        guard let date = dateFormatter.date(from: self) else { return nil }
+        
+        dateFormatter.dateFormat = "yyyy년 M월 d일 H시 mm분"
+        return dateFormatter.string(from: date)
+    }
+    
     func subStringToDate() -> String {
         let startIdx: String.Index = self.index(self.startIndex, offsetBy: 2)
         return String(self[startIdx...])

--- a/fairer-iOS/fairer-iOS/Network/API/TeamsAPI.swift
+++ b/fairer-iOS/fairer-iOS/Network/API/TeamsAPI.swift
@@ -15,6 +15,7 @@ final class TeamsAPI {
     
     private enum ResponseData {
         case getTeamInfo
+        case getInviteCodeInfo
         case postAddTeam
         case postJoinTeam
         case patchTeamInfo
@@ -27,6 +28,20 @@ final class TeamsAPI {
                 let statusCode = response.statusCode
                 let data = response.data
                 let networkResult = self.judgeStatus(by: statusCode, data, responseData: .getTeamInfo)
+                completion(networkResult)
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+    
+    func getInviteCodeInfo(completion: @escaping (NetworkResult<Any>) -> Void) {
+        teamsProvider.request(.getTeamInfo) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = self.judgeStatus(by: statusCode, data, responseData: .getInviteCodeInfo)
                 completion(networkResult)
             case .failure(let err):
                 print(err)
@@ -82,7 +97,7 @@ final class TeamsAPI {
         switch statusCode {
         case 200..<300:
             switch responseData {
-            case .getTeamInfo, .postAddTeam, .postJoinTeam, .patchTeamInfo:
+            case .getTeamInfo, .getInviteCodeInfo, .postAddTeam, .postJoinTeam, .patchTeamInfo:
                 return isValidData(data: data, responseData: responseData)
             }
         case 400:
@@ -107,6 +122,11 @@ final class TeamsAPI {
         switch responseData {
         case .getTeamInfo:
             guard let decodedData = try? decoder.decode(TeamInfoResponse.self, from: data) else {
+                return .pathErr
+            }
+            return .success(decodedData)
+        case .getInviteCodeInfo:
+            guard let decodedData = try? decoder.decode(InviteCodeInfoResponse.self, from: data) else {
                 return .pathErr
             }
             return .success(decodedData)

--- a/fairer-iOS/fairer-iOS/Network/API/TeamsAPI.swift
+++ b/fairer-iOS/fairer-iOS/Network/API/TeamsAPI.swift
@@ -36,7 +36,7 @@ final class TeamsAPI {
     }
     
     func getInviteCodeInfo(completion: @escaping (NetworkResult<Any>) -> Void) {
-        teamsProvider.request(.getTeamInfo) { result in
+        teamsProvider.request(.getInviteCodeInfo) { result in
             switch result {
             case .success(let response):
                 let statusCode = response.statusCode

--- a/fairer-iOS/fairer-iOS/Network/DTO/Teams/InviteCodeInfoResponse.swift
+++ b/fairer-iOS/fairer-iOS/Network/DTO/Teams/InviteCodeInfoResponse.swift
@@ -6,7 +6,7 @@
 //
 
 struct InviteCodeInfoResponse: Codable {
-    let inviteCode: String
-    let inviteCodeExpirationDateTime: String
-    let teamName: Int
+    let inviteCode: String?
+    let inviteCodeExpirationDateTime: String?
+    let teamName: String?
 }

--- a/fairer-iOS/fairer-iOS/Network/DTO/Teams/InviteCodeInfoResponse.swift
+++ b/fairer-iOS/fairer-iOS/Network/DTO/Teams/InviteCodeInfoResponse.swift
@@ -1,0 +1,12 @@
+//
+//  InviteCodeInfoResponse.swift
+//  fairer-iOS
+//
+//  Created by 김규철 on 2023/04/06.
+//
+
+struct InviteCodeInfoResponse: Codable {
+    let inviteCode: String
+    let inviteCodeExpirationDateTime: String
+    let teamName: Int
+}

--- a/fairer-iOS/fairer-iOS/Network/DTO/Teams/TeamInfoResponse.swift
+++ b/fairer-iOS/fairer-iOS/Network/DTO/Teams/TeamInfoResponse.swift
@@ -5,8 +5,6 @@
 //  Created by 김유나 on 2023/03/02.
 //
 
-import Foundation
-
 struct TeamInfoResponse: Codable {
     let members: [MemberResponse]?
     let teamId: Int?

--- a/fairer-iOS/fairer-iOS/Network/Router/TeamsRouter.swift
+++ b/fairer-iOS/fairer-iOS/Network/Router/TeamsRouter.swift
@@ -11,6 +11,7 @@ import Moya
 
 enum TeamsRouter {
     case getTeamInfo
+    case getInviteCodeInfo
     case postAddTeam(teamName: String)
     case postJoinTeam(inviteCode: String)
     case patchTeamInfo(teamName: String)
@@ -21,6 +22,8 @@ extension TeamsRouter: BaseTargetType {
         switch self {
         case .getTeamInfo:
             return URLConstant.teams + "/my"
+        case .getInviteCodeInfo:
+            return URLConstant.teams + "/invite-codes"
         case .postAddTeam, .patchTeamInfo:
             return URLConstant.teams
         case .postJoinTeam:
@@ -30,7 +33,7 @@ extension TeamsRouter: BaseTargetType {
     
     var method: Moya.Method {
         switch self {
-        case .getTeamInfo:
+        case .getTeamInfo, .getInviteCodeInfo:
             return .get
         case .postAddTeam, .postJoinTeam:
             return .post
@@ -41,7 +44,7 @@ extension TeamsRouter: BaseTargetType {
     
     var task: Moya.Task {
         switch self {
-        case .getTeamInfo:
+        case .getTeamInfo, .getInviteCodeInfo:
             return .requestPlain
         case .postAddTeam(let teamName), .patchTeamInfo(let teamName):
             return .requestParameters(parameters: ["teamName": teamName], encoding: JSONEncoding.default)


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #142 

## 👩‍💻 Contents & Screenshot
<!-- 작업 내용과 이미지를 첨부해주세요. -->

<img src="https://user-images.githubusercontent.com/25146374/230753142-d7cd5d2f-9040-44f4-8428-51751278a08c.png" width="200" height="400"/> <img src="https://user-images.githubusercontent.com/25146374/230753209-7d22985d-3622-4460-8c2b-28cba297a4c0.png" width="200" height="400"/>

- 코드 유효 시간 ( 중간 빨간 레이블) 데이터를 파싱하여 바인딩시켰습니다.
- 코드 재발급 버튼 선택 시 팀 초대 API 재실행

## 📌 Review Point
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->

- 하우스 이름과 초대코드가 처음에 뜨지 않는 이유는 두 개의 데이터는 push되기 전 뷰인 houseMakeNameVC에서 가져오기 때문에 팀 생성 API를 한번 호출 후 push 될 때 가져오게 됩니다.
- "2023-04-09T19:00:18" 형식으로 코드 만료 기간이 내려와서 해당 형식을 파싱하는 extension을 추가 했습니다.
- 코드 만료 기간과 date를 비교해서 코드 만료기간이 date보다 앞설 시 코드 카카오톡 공유하기 뷰가 else 면 코드 재발급 버튼이 뜨도록 했습니다.

## 🔓 Next Step
<!-- 다음으로 할 일을 적어주세요. -->
- setting에서의 HouseInviteCodeView