### PR TITLE
[ADD] 홈뷰 상단 팀 멤버 리스트 중 본인 확인

### DIFF
--- a/fairer-iOS/fairer-iOS/Global/UIComponent/LoadingView.swift
+++ b/fairer-iOS/fairer-iOS/Global/UIComponent/LoadingView.swift
@@ -17,7 +17,7 @@ final class LoadingView {
                     loadingView.startAnimating()
                     return
                 }
-                let loadingView = UIActivityIndicatorView(style: .large)
+                let loadingView = UIActivityIndicatorView(style: .medium)
                 loadingView.frame = window.bounds
                 loadingView.color = .darkGray
                 window.addSubview(loadingView)

--- a/fairer-iOS/fairer-iOS/Network/API/TeamsAPI.swift
+++ b/fairer-iOS/fairer-iOS/Network/API/TeamsAPI.swift
@@ -112,8 +112,7 @@ final class TeamsAPI {
         switch statusCode {
         case 200..<300:
             switch responseData {
-            case .getTeamInfo, .getInviteCodeInfo, .postAddTeam, .postJoinTeam, .patchTeamInfo:
-            case .getTeamInfo, .postAddTeam, .postJoinTeam, .patchTeamInfo, .postLeaveTeam:
+            case .getTeamInfo, .getInviteCodeInfo, .postAddTeam, .postJoinTeam, .postLeaveTeam, .patchTeamInfo:
                 return isValidData(data: data, responseData: responseData)
             }
         case 400:

--- a/fairer-iOS/fairer-iOS/Network/Router/TeamsRouter.swift
+++ b/fairer-iOS/fairer-iOS/Network/Router/TeamsRouter.swift
@@ -47,8 +47,7 @@ extension TeamsRouter: BaseTargetType {
     
     var task: Moya.Task {
         switch self {
-        case .getTeamInfo, .getInviteCodeInfo:
-        case .getTeamInfo, .postLeaveTeam:
+        case .getTeamInfo, .postLeaveTeam, .getInviteCodeInfo:
             return .requestPlain
         case .postAddTeam(let teamName), .patchTeamInfo(let teamName):
             return .requestParameters(parameters: ["teamName": teamName], encoding: JSONEncoding.default)

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/WeekCalendarView/HomeWeekCalendarCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/WeekCalendarView/HomeWeekCalendarCollectionView.swift
@@ -10,9 +10,9 @@ import UIKit
 import SnapKit
 
 final class HomeWeekCalendarCollectionView: BaseUIView {
-
+    
     static let indentifer = "reusableView"
-
+    
     lazy var fullDateList: [String] = [] {
         didSet {
             self.collectionView.reloadData()
@@ -23,6 +23,7 @@ final class HomeWeekCalendarCollectionView: BaseUIView {
             self.collectionView.reloadData()
         }
     }
+    var countWorkLeftWeekCalendar: [Int]?
     lazy var dotList: [UIImage] = [] {
         didSet {
             self.collectionView.reloadData()
@@ -186,15 +187,17 @@ extension HomeWeekCalendarCollectionView: UICollectionViewDataSource {
                 cell.dayLabel.textColor = UIColor.blue
                 cell.dayLabel.font = .title2
                 cell.dateLabel.font = .title2
-                if Int(countWorkLeft) == 0 {
-                    cell.workDot.image = dotList[indexPath.row]
-                    cell.workBlueBadge.isHidden = true
-                    cell.workLeftLabel.isHidden = true
-                } else {
-                    cell.workDot.isHidden = true
-                    cell.workBlueBadge.isHidden = false
-                    cell.workLeftLabel.isHidden = false
-                    cell.workLeftLabel.text = self.countWorkLeft
+                if let countWorkLeftWeekCalendar = countWorkLeftWeekCalendar {
+                    if countWorkLeftWeekCalendar[indexPath.row] == 0 {
+                        cell.workDot.image = dotList[indexPath.row]
+                        cell.workBlueBadge.isHidden = true
+                        cell.workLeftLabel.isHidden = true
+                    } else {
+                        cell.workDot.isHidden = true
+                        cell.workBlueBadge.isHidden = false
+                        cell.workLeftLabel.isHidden = false
+                        cell.workLeftLabel.text = self.countWorkLeft
+                    }
                 }
             }
             return cell
@@ -207,15 +210,17 @@ extension HomeWeekCalendarCollectionView: UICollectionViewDataSource {
             cell.dayLabel.textColor = UIColor.blue
             cell.dayLabel.font = .title2
             cell.dateLabel.font = .title2
-            if Int(countWorkLeft) == 0 {
-                cell.workDot.image = dotList[indexPath.row]
-                cell.workBlueBadge.isHidden = true
-                cell.workLeftLabel.isHidden = true
-            } else {
-                cell.workDot.isHidden = true
-                cell.workBlueBadge.isHidden = false
-                cell.workLeftLabel.isHidden = false
-                cell.workLeftLabel.text = self.countWorkLeft
+            if let countWorkLeftWeekCalendar = countWorkLeftWeekCalendar {
+                if countWorkLeftWeekCalendar[indexPath.row] == 0 {
+                    cell.workDot.image = dotList[indexPath.row]
+                    cell.workBlueBadge.isHidden = true
+                    cell.workLeftLabel.isHidden = true
+                } else {
+                    cell.workDot.isHidden = true
+                    cell.workBlueBadge.isHidden = false
+                    cell.workLeftLabel.isHidden = false
+                    cell.workLeftLabel.text = self.countWorkLeft
+                }
             }
         }
         return cell

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/WeekCalendarView/HomeWeekCalendarCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/WeekCalendarView/HomeWeekCalendarCollectionView.swift
@@ -131,7 +131,6 @@ final class HomeWeekCalendarCollectionView: BaseUIView {
         self.fullDateList = resultFullWeekData
         self.datePickedByOthers = self.fullDateList.first ?? String()
         yearMonthDateByTouchedCell?(self.fullDateList.first ?? String())
-        collectionView.reloadData()
     }
     
     func getBeforeWeekDate() {
@@ -147,7 +146,6 @@ final class HomeWeekCalendarCollectionView: BaseUIView {
         self.fullDateList = resultFullWeekData
         self.datePickedByOthers = self.fullDateList.first ?? String()
         yearMonthDateByTouchedCell?(self.fullDateList.first ?? String())
-        collectionView.reloadData()
     }
 }
 

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -119,7 +119,7 @@ final class HomeViewController: BaseViewController {
         return view
     }()
     private let homeCalenderView = HomeCalendarView()
-    private let homeWeekCalendarCollectionView = HomeWeekCalendarCollectionView()
+    private var homeWeekCalendarCollectionView = HomeWeekCalendarCollectionView()
     private let calendarDailyTableView: UITableView = {
         let calendarDailyTableView = UITableView(frame: .zero, style: .insetGrouped)
         calendarDailyTableView.register(CalendarDailyTableViewCell.self, forCellReuseIdentifier: CalendarDailyTableViewCell.identifier)
@@ -592,6 +592,7 @@ final class HomeViewController: BaseViewController {
                     self.homeWeekCalendarCollectionView.dotList = [UIImage]()
                     for date in self.homeWeekCalendarCollectionView.fullDateList {
                         if let workDate = response[date.replacingOccurrences(of: ".", with: "-")] {
+                            self.homeWeekCalendarCollectionView.countWorkLeftWeekCalendar?.append(workDate.countLeft)
                             doneWorkSum = doneWorkSum + workDate.countDone
                             switch workDate.countLeft {
                             case 0:
@@ -606,7 +607,6 @@ final class HomeViewController: BaseViewController {
                         }
                     }
                     self.countWorkDoneInWeek = doneWorkSum
-                    self.homeWeekCalendarCollectionView.collectionView.reloadData()
                     self.calendarDailyTableView.reloadData()
                 }
             } else {
@@ -619,6 +619,7 @@ final class HomeViewController: BaseViewController {
                     self.homeWeekCalendarCollectionView.dotList = [UIImage]()
                     for date in self.homeWeekCalendarCollectionView.fullDateList {
                         if let workDate = response[date.replacingOccurrences(of: ".", with: "-")] {
+                            self.homeWeekCalendarCollectionView.countWorkLeftWeekCalendar?.append(workDate.countLeft)
                             doneWorkSum = doneWorkSum + workDate.countDone
                             switch workDate.countLeft {
                             case 0:
@@ -633,7 +634,6 @@ final class HomeViewController: BaseViewController {
                         }
                     }
                     self.countWorkDoneInWeek = doneWorkSum
-                    self.homeWeekCalendarCollectionView.collectionView.reloadData()
                     self.calendarDailyTableView.reloadData()
                 }
             }

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -583,32 +583,38 @@ final class HomeViewController: BaseViewController {
         guard let firstDateInFullDateList = self.homeWeekCalendarCollectionView.fullDateList.first else { return }
         guard let lastDateInFullDateList = self.homeWeekCalendarCollectionView.fullDateList.last else { return }
         var doneWorkSum: Int = 0
+        DispatchQueue.main.async {
+            LoadingView.showLoading()
+        }
         DispatchQueue.global().async {
             if isOwn {
                 self.getDateHouseWork(
                     fromDate: firstDateInFullDateList.replacingOccurrences(of: ".", with: "-"),
                     toDate: lastDateInFullDateList.replacingOccurrences(of: ".", with: "-")
                 ) { response in
-                    self.homeWeekCalendarCollectionView.countWorkLeftWeekCalendar = [Int]()
-                    self.homeWeekCalendarCollectionView.dotList = [UIImage]()
-                    for date in self.homeWeekCalendarCollectionView.fullDateList {
-                        if let workDate = response[date.replacingOccurrences(of: ".", with: "-")] {
-                            self.homeWeekCalendarCollectionView.countWorkLeftWeekCalendar?.append(workDate.countLeft)
-                            doneWorkSum = doneWorkSum + workDate.countDone
-                            switch workDate.countLeft {
-                            case 0:
-                                self.homeWeekCalendarCollectionView.dotList.append(UIImage())
-                            case 1...3:
-                                self.homeWeekCalendarCollectionView.dotList.append(ImageLiterals.oneDot)
-                            case 4...6:
-                                self.homeWeekCalendarCollectionView.dotList.append(ImageLiterals.twoDots)
-                            default:
-                                self.homeWeekCalendarCollectionView.dotList.append(ImageLiterals.threeDots)
+                    DispatchQueue.main.async {
+                        LoadingView.hideLoading()
+                        self.homeWeekCalendarCollectionView.countWorkLeftWeekCalendar = [Int]()
+                        self.homeWeekCalendarCollectionView.dotList = [UIImage]()
+                        for date in self.homeWeekCalendarCollectionView.fullDateList {
+                            if let workDate = response[date.replacingOccurrences(of: ".", with: "-")] {
+                                self.homeWeekCalendarCollectionView.countWorkLeftWeekCalendar?.append(workDate.countLeft)
+                                doneWorkSum = doneWorkSum + workDate.countDone
+                                switch workDate.countLeft {
+                                case 0:
+                                    self.homeWeekCalendarCollectionView.dotList.append(UIImage())
+                                case 1...3:
+                                    self.homeWeekCalendarCollectionView.dotList.append(ImageLiterals.oneDot)
+                                case 4...6:
+                                    self.homeWeekCalendarCollectionView.dotList.append(ImageLiterals.twoDots)
+                                default:
+                                    self.homeWeekCalendarCollectionView.dotList.append(ImageLiterals.threeDots)
+                                }
                             }
                         }
+                        self.countWorkDoneInWeek = doneWorkSum
+                        self.calendarDailyTableView.reloadData()
                     }
-                    self.countWorkDoneInWeek = doneWorkSum
-                    self.calendarDailyTableView.reloadData()
                 }
             } else {
                 guard let selectedMemberId = self.selectedMemberId else { return }
@@ -617,26 +623,29 @@ final class HomeViewController: BaseViewController {
                     toDate: lastDateInFullDateList.replacingOccurrences(of: ".", with: "-"),
                     teamMemberId: selectedMemberId
                 ) { response in
-                    self.homeWeekCalendarCollectionView.countWorkLeftWeekCalendar = [Int]()
-                    self.homeWeekCalendarCollectionView.dotList = [UIImage]()
-                    for date in self.homeWeekCalendarCollectionView.fullDateList {
-                        if let workDate = response[date.replacingOccurrences(of: ".", with: "-")] {
-                            self.homeWeekCalendarCollectionView.countWorkLeftWeekCalendar?.append(workDate.countLeft)
-                            doneWorkSum = doneWorkSum + workDate.countDone
-                            switch workDate.countLeft {
-                            case 0:
-                                self.homeWeekCalendarCollectionView.dotList.append(UIImage())
-                            case 1...3:
-                                self.homeWeekCalendarCollectionView.dotList.append(ImageLiterals.oneDot)
-                            case 4...6:
-                                self.homeWeekCalendarCollectionView.dotList.append(ImageLiterals.twoDots)
-                            default:
-                                self.homeWeekCalendarCollectionView.dotList.append(ImageLiterals.threeDots)
+                    DispatchQueue.main.async {
+                        LoadingView.hideLoading()
+                        self.homeWeekCalendarCollectionView.countWorkLeftWeekCalendar = [Int]()
+                        self.homeWeekCalendarCollectionView.dotList = [UIImage]()
+                        for date in self.homeWeekCalendarCollectionView.fullDateList {
+                            if let workDate = response[date.replacingOccurrences(of: ".", with: "-")] {
+                                self.homeWeekCalendarCollectionView.countWorkLeftWeekCalendar?.append(workDate.countLeft)
+                                doneWorkSum = doneWorkSum + workDate.countDone
+                                switch workDate.countLeft {
+                                case 0:
+                                    self.homeWeekCalendarCollectionView.dotList.append(UIImage())
+                                case 1...3:
+                                    self.homeWeekCalendarCollectionView.dotList.append(ImageLiterals.oneDot)
+                                case 4...6:
+                                    self.homeWeekCalendarCollectionView.dotList.append(ImageLiterals.twoDots)
+                                default:
+                                    self.homeWeekCalendarCollectionView.dotList.append(ImageLiterals.threeDots)
+                                }
                             }
                         }
+                        self.countWorkDoneInWeek = doneWorkSum
+                        self.calendarDailyTableView.reloadData()
                     }
-                    self.countWorkDoneInWeek = doneWorkSum
-                    self.calendarDailyTableView.reloadData()
                 }
             }
         }

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -589,6 +589,7 @@ final class HomeViewController: BaseViewController {
                     fromDate: firstDateInFullDateList.replacingOccurrences(of: ".", with: "-"),
                     toDate: lastDateInFullDateList.replacingOccurrences(of: ".", with: "-")
                 ) { response in
+                    self.homeWeekCalendarCollectionView.countWorkLeftWeekCalendar = [Int]()
                     self.homeWeekCalendarCollectionView.dotList = [UIImage]()
                     for date in self.homeWeekCalendarCollectionView.fullDateList {
                         if let workDate = response[date.replacingOccurrences(of: ".", with: "-")] {
@@ -616,6 +617,7 @@ final class HomeViewController: BaseViewController {
                     toDate: lastDateInFullDateList.replacingOccurrences(of: ".", with: "-"),
                     teamMemberId: selectedMemberId
                 ) { response in
+                    self.homeWeekCalendarCollectionView.countWorkLeftWeekCalendar = [Int]()
                     self.homeWeekCalendarCollectionView.dotList = [UIImage]()
                     for date in self.homeWeekCalendarCollectionView.fullDateList {
                         if let workDate = response[date.replacingOccurrences(of: ".", with: "-")] {

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -486,7 +486,7 @@ final class HomeViewController: BaseViewController {
     
     private func getHouseWorksByDate(isOwn: Bool, startDate: String, endDate: String) {
         DispatchQueue.main.async {
-            LoadingView.showLoading()
+            self.view.isUserInteractionEnabled = false
         }
         DispatchQueue.global().async {
             if isOwn {
@@ -495,7 +495,7 @@ final class HomeViewController: BaseViewController {
                     toDate: endDate.replacingOccurrences(of: ".", with: "-")
                 ) { response in
                     DispatchQueue.main.async {
-                        LoadingView.hideLoading()
+                        self.view.isUserInteractionEnabled = true
                         if let response = response[self.homeWeekCalendarCollectionView.datePickedByOthers.replacingOccurrences(of: ".", with: "-")] {
                             self.pickDayWorkInfo = response
                             self.divideIndex = response.countLeft
@@ -524,7 +524,7 @@ final class HomeViewController: BaseViewController {
                     teamMemberId: selectedMemberId
                 ) { response in
                     DispatchQueue.main.async {
-                        LoadingView.hideLoading()
+                        self.view.isUserInteractionEnabled = true
                         if let response = response[self.homeWeekCalendarCollectionView.datePickedByOthers.replacingOccurrences(of: ".", with: "-")] {
                             self.pickDayWorkInfo = response
                             self.divideIndex = response.countLeft
@@ -584,7 +584,7 @@ final class HomeViewController: BaseViewController {
         guard let lastDateInFullDateList = self.homeWeekCalendarCollectionView.fullDateList.last else { return }
         var doneWorkSum: Int = 0
         DispatchQueue.main.async {
-            LoadingView.showLoading()
+            self.view.isUserInteractionEnabled = false
         }
         DispatchQueue.global().async {
             if isOwn {
@@ -593,7 +593,7 @@ final class HomeViewController: BaseViewController {
                     toDate: lastDateInFullDateList.replacingOccurrences(of: ".", with: "-")
                 ) { response in
                     DispatchQueue.main.async {
-                        LoadingView.hideLoading()
+                        self.view.isUserInteractionEnabled = true
                         self.homeWeekCalendarCollectionView.countWorkLeftWeekCalendar = [Int]()
                         self.homeWeekCalendarCollectionView.dotList = [UIImage]()
                         for date in self.homeWeekCalendarCollectionView.fullDateList {
@@ -624,7 +624,7 @@ final class HomeViewController: BaseViewController {
                     teamMemberId: selectedMemberId
                 ) { response in
                     DispatchQueue.main.async {
-                        LoadingView.hideLoading()
+                        self.view.isUserInteractionEnabled = true
                         self.homeWeekCalendarCollectionView.countWorkLeftWeekCalendar = [Int]()
                         self.homeWeekCalendarCollectionView.dotList = [UIImage]()
                         for date in self.homeWeekCalendarCollectionView.fullDateList {

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -493,7 +493,10 @@ final class HomeViewController: BaseViewController {
                 self.getDateHouseWork(
                     fromDate: startDate.replacingOccurrences(of: ".", with: "-"),
                     toDate: endDate.replacingOccurrences(of: ".", with: "-")
-                ) { response in
+                ) { [weak self] response in
+                    guard let self = self else {
+                        return
+                    }
                     DispatchQueue.main.async {
                         self.view.isUserInteractionEnabled = true
                         if let response = response[self.homeWeekCalendarCollectionView.datePickedByOthers.replacingOccurrences(of: ".", with: "-")] {
@@ -522,7 +525,10 @@ final class HomeViewController: BaseViewController {
                     fromDate: startDate.replacingOccurrences(of: ".", with: "-"),
                     toDate: endDate.replacingOccurrences(of: ".", with: "-"),
                     teamMemberId: selectedMemberId
-                ) { response in
+                ) { [weak self] response in
+                    guard let self = self else {
+                        return
+                    }
                     DispatchQueue.main.async {
                         self.view.isUserInteractionEnabled = true
                         if let response = response[self.homeWeekCalendarCollectionView.datePickedByOthers.replacingOccurrences(of: ".", with: "-")] {
@@ -549,31 +555,41 @@ final class HomeViewController: BaseViewController {
     }
     
     private func getRules() {
-        self.getRulesFromServer() { response in
+        self.getRulesFromServer() { [weak self] response in
+            guard let self = self else {
+                return
+            }
             self.ruleArray = response.ruleResponseDtos
             self.setHomeRuleLabel()
         }
     }
     
     private func getMyInfo() {
-        self.getMyInfoFromServer { response in
+        self.getMyInfoFromServer { [weak self] response in
+            guard let self = self else {
+                return
+            }
             self.myId = response.memberId
             self.getTeamInfo()
         }
     }
     
     private func getTeamInfo() {
-        self.getTeamInfoFromServer() { response in
+        self.getTeamInfoFromServer() { [weak self] response in
+            guard let self = self else {
+                return
+            }
             self.homeGroupLabel.text = response.teamName
             self.selectedMemberId = self.myId
             self.teamId = response.teamId
-            guard let teamMember = response.members else { return }
-            for member in teamMember {
-                if self.myId == member.memberId {
-                    self.homeGroupCollectionView.userList.insert(member, at: 0)
-                    self.userName = member.memberName ?? ""
-                } else {
-                    self.homeGroupCollectionView.userList.append(member)
+            if let teamMember = response.members {
+                for member in teamMember {
+                    if self.myId == member.memberId {
+                        self.homeGroupCollectionView.userList.insert(member, at: 0)
+                        self.userName = member.memberName ?? ""
+                    } else {
+                        self.homeGroupCollectionView.userList.append(member)
+                    }
                 }
             }
         }
@@ -591,7 +607,10 @@ final class HomeViewController: BaseViewController {
                 self.getDateHouseWork(
                     fromDate: firstDateInFullDateList.replacingOccurrences(of: ".", with: "-"),
                     toDate: lastDateInFullDateList.replacingOccurrences(of: ".", with: "-")
-                ) { response in
+                ) { [weak self] response in
+                    guard let self = self else {
+                        return
+                    }
                     DispatchQueue.main.async {
                         self.view.isUserInteractionEnabled = true
                         self.homeWeekCalendarCollectionView.countWorkLeftWeekCalendar = [Int]()
@@ -622,7 +641,10 @@ final class HomeViewController: BaseViewController {
                     fromDate: firstDateInFullDateList.replacingOccurrences(of: ".", with: "-"),
                     toDate: lastDateInFullDateList.replacingOccurrences(of: ".", with: "-"),
                     teamMemberId: selectedMemberId
-                ) { response in
+                ) { [weak self] response in
+                    guard let self = self else {
+                        return
+                    }
                     DispatchQueue.main.async {
                         self.view.isUserInteractionEnabled = true
                         self.homeWeekCalendarCollectionView.countWorkLeftWeekCalendar = [Int]()
@@ -642,6 +664,7 @@ final class HomeViewController: BaseViewController {
                                     self.homeWeekCalendarCollectionView.dotList.append(ImageLiterals.threeDots)
                                 }
                             }
+                            
                         }
                         self.countWorkDoneInWeek = doneWorkSum
                         self.calendarDailyTableView.reloadData()


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #147

## 👩‍💻 Contents & Screenshot
<!-- 작업 내용과 이미지를 첨부해주세요. -->
![Simulator Screen Recording - iPhone 14 - 2023-04-09 at 17 15 14](https://user-images.githubusercontent.com/83629193/230761968-27209500-227e-4303-adbd-94cf98007979.gif)

1. 본인 정보 조회 이후 팀 정보 조회하여 본인 아이콘이 상단 팀 리스트에서 가장 왼쪽에 오도록 구현
2. 기본 loading view -> self.view.isUserInteractionEnabled 로 대체
3. 홈뷰 처음 들어갔을 때 의미 없이 뜨던 파란 뱃지 버그 해결
4. 주간 캘린더 가로 스크롤 연속으로 했을 때 발생되던 인덱스 참조 버그 해결
5. 다른 예외 상황 처리에서 Loading View 사용할것 같아 일단 남겨두었어요

## 📌 Review Point
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- 홈뷰에서 데이터 바인딩 속도가 조금 느린 부분이 있는데 (파란 뱃지), 해당 부분은 좀 더 고민해보려해요!

## 🔓 Next Step
<!-- 다음으로 할 일을 적어주세요. -->
- 홈뷰는 팀원 이미지 로딩만 해결만 남았고 전체적으로 마무리 되었습니다.

