### PR TITLE
[FIX] 버그 테이블 기반 디버깅

### DIFF
--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -155,28 +155,8 @@
 		917D8B8029A634CA00E26B73 /* URLConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917D8B7F29A634CA00E26B73 /* URLConstant.swift */; };
 		917D8B8229A6355500E26B73 /* FCMRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917D8B8129A6355500E26B73 /* FCMRouter.swift */; };
 		917D8B8829A63AA500E26B73 /* FcmAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917D8B8729A63AA500E26B73 /* FcmAPI.swift */; };
-		91AAF92B29DD900B00CB1E1A /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF92A29DD900B00CB1E1A /* FirebaseAnalytics */; };
-		91AAF92D29DD900B00CB1E1A /* FirebaseAnalyticsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF92C29DD900B00CB1E1A /* FirebaseAnalyticsOnDeviceConversion */; };
-		91AAF92F29DD900B00CB1E1A /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF92E29DD900B00CB1E1A /* FirebaseAnalyticsSwift */; };
-		91AAF93129DD900B00CB1E1A /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF93029DD900B00CB1E1A /* FirebaseAnalyticsWithoutAdIdSupport */; };
-		91AAF93329DD900B00CB1E1A /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF93229DD900B00CB1E1A /* FirebaseAppCheck */; };
-		91AAF93529DD900B00CB1E1A /* FirebaseAppDistribution-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF93429DD900B00CB1E1A /* FirebaseAppDistribution-Beta */; };
-		91AAF93729DD900B00CB1E1A /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF93629DD900B00CB1E1A /* FirebaseCrashlytics */; };
-		91AAF93929DD900B00CB1E1A /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF93829DD900B00CB1E1A /* FirebaseDatabase */; };
-		91AAF93B29DD900B00CB1E1A /* FirebaseDatabaseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF93A29DD900B00CB1E1A /* FirebaseDatabaseSwift */; };
-		91AAF93D29DD900B00CB1E1A /* FirebaseDynamicLinks in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF93C29DD900B00CB1E1A /* FirebaseDynamicLinks */; };
-		91AAF93F29DD900B00CB1E1A /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF93E29DD900B00CB1E1A /* FirebaseFunctions */; };
-		91AAF94129DD900B00CB1E1A /* FirebaseFunctionsCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF94029DD900B00CB1E1A /* FirebaseFunctionsCombine-Community */; };
-		91AAF94329DD900B00CB1E1A /* FirebaseInAppMessaging-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF94229DD900B00CB1E1A /* FirebaseInAppMessaging-Beta */; };
-		91AAF94529DD900B00CB1E1A /* FirebaseInAppMessagingSwift-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF94429DD900B00CB1E1A /* FirebaseInAppMessagingSwift-Beta */; };
-		91AAF94729DD900B00CB1E1A /* FirebaseInstallations in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF94629DD900B00CB1E1A /* FirebaseInstallations */; };
-		91AAF94929DD900B00CB1E1A /* FirebaseMLModelDownloader in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF94829DD900B00CB1E1A /* FirebaseMLModelDownloader */; };
-		91AAF94B29DD900B00CB1E1A /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF94A29DD900B00CB1E1A /* FirebaseMessaging */; };
-		91AAF94D29DD900B00CB1E1A /* FirebasePerformance in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF94C29DD900B00CB1E1A /* FirebasePerformance */; };
-		91AAF94F29DD900B00CB1E1A /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF94E29DD900B00CB1E1A /* FirebaseRemoteConfig */; };
-		91AAF95129DD900B00CB1E1A /* FirebaseRemoteConfigSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF95029DD900B00CB1E1A /* FirebaseRemoteConfigSwift */; };
-		91AAF95329DD900B00CB1E1A /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF95229DD900B00CB1E1A /* FirebaseStorage */; };
-		91AAF95529DD900B00CB1E1A /* FirebaseStorageCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 91AAF95429DD900B00CB1E1A /* FirebaseStorageCombine-Community */; };
+		91AF387929E9DA73000C4EFD /* FirebaseDynamicLinks in Frameworks */ = {isa = PBXBuildFile; productRef = 91AF387829E9DA73000C4EFD /* FirebaseDynamicLinks */; };
+		91AF387B29E9DA73000C4EFD /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 91AF387A29E9DA73000C4EFD /* FirebaseMessaging */; };
 		91CB591C29977B09002A3295 /* PickDateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91CB591B29977B09002A3295 /* PickDateView.swift */; };
 		91D6870629E7DCC90046AAA8 /* UINavigationController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D6870529E7DCC90046AAA8 /* UINavigationController+Extension.swift */; };
 		91D6A0C629AE2BFA0051FFE2 /* AuthResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D6A0C529AE2BFA0051FFE2 /* AuthResponse.swift */; };
@@ -343,32 +323,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				91AAF94D29DD900B00CB1E1A /* FirebasePerformance in Frameworks */,
+				91AF387B29E9DA73000C4EFD /* FirebaseMessaging in Frameworks */,
 				7E1F2E2528D2123B00A5744A /* SnapKit in Frameworks */,
-				91AAF92D29DD900B00CB1E1A /* FirebaseAnalyticsOnDeviceConversion in Frameworks */,
-				91AAF95329DD900B00CB1E1A /* FirebaseStorage in Frameworks */,
 				5227557028B3092A0080DD65 /* GoogleSignIn in Frameworks */,
 				917D8B5829A631C500E26B73 /* Moya in Frameworks */,
-				91AAF92F29DD900B00CB1E1A /* FirebaseAnalyticsSwift in Frameworks */,
-				91AAF94329DD900B00CB1E1A /* FirebaseInAppMessaging-Beta in Frameworks */,
-				91AAF93D29DD900B00CB1E1A /* FirebaseDynamicLinks in Frameworks */,
-				91AAF94929DD900B00CB1E1A /* FirebaseMLModelDownloader in Frameworks */,
-				91AAF95129DD900B00CB1E1A /* FirebaseRemoteConfigSwift in Frameworks */,
-				91AAF93729DD900B00CB1E1A /* FirebaseCrashlytics in Frameworks */,
-				91AAF94B29DD900B00CB1E1A /* FirebaseMessaging in Frameworks */,
-				91AAF94729DD900B00CB1E1A /* FirebaseInstallations in Frameworks */,
-				91AAF94129DD900B00CB1E1A /* FirebaseFunctionsCombine-Community in Frameworks */,
-				91AAF93B29DD900B00CB1E1A /* FirebaseDatabaseSwift in Frameworks */,
-				91AAF95529DD900B00CB1E1A /* FirebaseStorageCombine-Community in Frameworks */,
-				91AAF93929DD900B00CB1E1A /* FirebaseDatabase in Frameworks */,
-				91AAF92B29DD900B00CB1E1A /* FirebaseAnalytics in Frameworks */,
 				5227557428B30AF90080DD65 /* KakaoSDK in Frameworks */,
-				91AAF93529DD900B00CB1E1A /* FirebaseAppDistribution-Beta in Frameworks */,
-				91AAF94F29DD900B00CB1E1A /* FirebaseRemoteConfig in Frameworks */,
-				91AAF93F29DD900B00CB1E1A /* FirebaseFunctions in Frameworks */,
-				91AAF93329DD900B00CB1E1A /* FirebaseAppCheck in Frameworks */,
-				91AAF94529DD900B00CB1E1A /* FirebaseInAppMessagingSwift-Beta in Frameworks */,
-				91AAF93129DD900B00CB1E1A /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */,
+				91AF387929E9DA73000C4EFD /* FirebaseDynamicLinks in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1195,28 +1155,8 @@
 				5227557328B30AF90080DD65 /* KakaoSDK */,
 				7E1F2E2428D2123B00A5744A /* SnapKit */,
 				917D8B5729A631C500E26B73 /* Moya */,
-				91AAF92A29DD900B00CB1E1A /* FirebaseAnalytics */,
-				91AAF92C29DD900B00CB1E1A /* FirebaseAnalyticsOnDeviceConversion */,
-				91AAF92E29DD900B00CB1E1A /* FirebaseAnalyticsSwift */,
-				91AAF93029DD900B00CB1E1A /* FirebaseAnalyticsWithoutAdIdSupport */,
-				91AAF93229DD900B00CB1E1A /* FirebaseAppCheck */,
-				91AAF93429DD900B00CB1E1A /* FirebaseAppDistribution-Beta */,
-				91AAF93629DD900B00CB1E1A /* FirebaseCrashlytics */,
-				91AAF93829DD900B00CB1E1A /* FirebaseDatabase */,
-				91AAF93A29DD900B00CB1E1A /* FirebaseDatabaseSwift */,
-				91AAF93C29DD900B00CB1E1A /* FirebaseDynamicLinks */,
-				91AAF93E29DD900B00CB1E1A /* FirebaseFunctions */,
-				91AAF94029DD900B00CB1E1A /* FirebaseFunctionsCombine-Community */,
-				91AAF94229DD900B00CB1E1A /* FirebaseInAppMessaging-Beta */,
-				91AAF94429DD900B00CB1E1A /* FirebaseInAppMessagingSwift-Beta */,
-				91AAF94629DD900B00CB1E1A /* FirebaseInstallations */,
-				91AAF94829DD900B00CB1E1A /* FirebaseMLModelDownloader */,
-				91AAF94A29DD900B00CB1E1A /* FirebaseMessaging */,
-				91AAF94C29DD900B00CB1E1A /* FirebasePerformance */,
-				91AAF94E29DD900B00CB1E1A /* FirebaseRemoteConfig */,
-				91AAF95029DD900B00CB1E1A /* FirebaseRemoteConfigSwift */,
-				91AAF95229DD900B00CB1E1A /* FirebaseStorage */,
-				91AAF95429DD900B00CB1E1A /* FirebaseStorageCombine-Community */,
+				91AF387829E9DA73000C4EFD /* FirebaseDynamicLinks */,
+				91AF387A29E9DA73000C4EFD /* FirebaseMessaging */,
 			);
 			productName = "fairer-iOS";
 			productReference = 5227554C28B219DC0080DD65 /* fairer-iOS.app */;
@@ -1251,7 +1191,7 @@
 				5227557228B30AF90080DD65 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 				7E1F2E2328D2123B00A5744A /* XCRemoteSwiftPackageReference "SnapKit" */,
 				917D8B5629A631C500E26B73 /* XCRemoteSwiftPackageReference "Moya" */,
-				91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				91AF387729E9DA73000C4EFD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = 5227554D28B219DC0080DD65 /* Products */;
 			projectDirPath = "";
@@ -1655,12 +1595,12 @@
 				kind = branch;
 			};
 		};
-		91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+		91AF387729E9DA73000C4EFD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 9.0.0;
+				branch = master;
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -1686,115 +1626,15 @@
 			package = 917D8B5629A631C500E26B73 /* XCRemoteSwiftPackageReference "Moya" */;
 			productName = Moya;
 		};
-		91AAF92A29DD900B00CB1E1A /* FirebaseAnalytics */ = {
+		91AF387829E9DA73000C4EFD /* FirebaseDynamicLinks */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseAnalytics;
-		};
-		91AAF92C29DD900B00CB1E1A /* FirebaseAnalyticsOnDeviceConversion */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseAnalyticsOnDeviceConversion;
-		};
-		91AAF92E29DD900B00CB1E1A /* FirebaseAnalyticsSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseAnalyticsSwift;
-		};
-		91AAF93029DD900B00CB1E1A /* FirebaseAnalyticsWithoutAdIdSupport */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseAnalyticsWithoutAdIdSupport;
-		};
-		91AAF93229DD900B00CB1E1A /* FirebaseAppCheck */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseAppCheck;
-		};
-		91AAF93429DD900B00CB1E1A /* FirebaseAppDistribution-Beta */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = "FirebaseAppDistribution-Beta";
-		};
-		91AAF93629DD900B00CB1E1A /* FirebaseCrashlytics */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseCrashlytics;
-		};
-		91AAF93829DD900B00CB1E1A /* FirebaseDatabase */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseDatabase;
-		};
-		91AAF93A29DD900B00CB1E1A /* FirebaseDatabaseSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseDatabaseSwift;
-		};
-		91AAF93C29DD900B00CB1E1A /* FirebaseDynamicLinks */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			package = 91AF387729E9DA73000C4EFD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseDynamicLinks;
 		};
-		91AAF93E29DD900B00CB1E1A /* FirebaseFunctions */ = {
+		91AF387A29E9DA73000C4EFD /* FirebaseMessaging */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseFunctions;
-		};
-		91AAF94029DD900B00CB1E1A /* FirebaseFunctionsCombine-Community */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = "FirebaseFunctionsCombine-Community";
-		};
-		91AAF94229DD900B00CB1E1A /* FirebaseInAppMessaging-Beta */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = "FirebaseInAppMessaging-Beta";
-		};
-		91AAF94429DD900B00CB1E1A /* FirebaseInAppMessagingSwift-Beta */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = "FirebaseInAppMessagingSwift-Beta";
-		};
-		91AAF94629DD900B00CB1E1A /* FirebaseInstallations */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseInstallations;
-		};
-		91AAF94829DD900B00CB1E1A /* FirebaseMLModelDownloader */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseMLModelDownloader;
-		};
-		91AAF94A29DD900B00CB1E1A /* FirebaseMessaging */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			package = 91AF387729E9DA73000C4EFD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseMessaging;
-		};
-		91AAF94C29DD900B00CB1E1A /* FirebasePerformance */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebasePerformance;
-		};
-		91AAF94E29DD900B00CB1E1A /* FirebaseRemoteConfig */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseRemoteConfig;
-		};
-		91AAF95029DD900B00CB1E1A /* FirebaseRemoteConfigSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseRemoteConfigSwift;
-		};
-		91AAF95229DD900B00CB1E1A /* FirebaseStorage */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseStorage;
-		};
-		91AAF95429DD900B00CB1E1A /* FirebaseStorageCombine-Community */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 91AAF92929DD900A00CB1E1A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = "FirebaseStorageCombine-Community";
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/fairer-iOS/fairer-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "abseil-cpp-swiftpm",
+      "identity" : "abseil-cpp-binary",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/abseil-cpp-SwiftPM.git",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
       "state" : {
-        "revision" : "583de9bd60f66b40e78d08599cc92036c2e7e4e1",
-        "version" : "0.20220203.2"
+        "revision" : "a5f16ba68913840ee5df91b8dc06f5cc063579de",
+        "version" : "1.2021110200.0"
       }
     },
     {
@@ -23,17 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openid/AppAuth-iOS.git",
       "state" : {
-        "revision" : "33660c271c961f8ce1084cc13f2ea8195e864f7d",
-        "version" : "1.5.0"
-      }
-    },
-    {
-      "identity" : "boringssl-swiftpm",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/boringssl-SwiftPM.git",
-      "state" : {
-        "revision" : "dd3eda2b05a3f459fc3073695ad1b28659066eab",
-        "version" : "0.9.1"
+        "revision" : "0eadcdec4ddb121865f3d66917549194afce1f2b",
+        "version" : "1.6.1"
       }
     },
     {
@@ -41,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "7e80c25b51c2ffa238879b07fbfc5baa54bb3050",
-        "version" : "9.6.0"
+        "branch" : "master",
+        "revision" : "6504a2b98be383cc2d3c164284d186ac982d3a8c"
       }
     },
     {
@@ -50,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "c1cfde8067668027b23a42c29d11c246152fe046",
-        "version" : "9.6.0"
+        "revision" : "274428b83e063cd518b998555be0ec18abcbe9de",
+        "version" : "10.8.0"
       }
     },
     {
@@ -68,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleSignIn-iOS",
       "state" : {
-        "revision" : "5ce850448e89500aca5b095af7247eb46dc0ca18",
-        "version" : "6.2.3"
+        "revision" : "9c9b36af86a4dd3da16048a36cf37351e63ccfe1",
+        "version" : "6.2.4"
       }
     },
     {
@@ -82,12 +73,12 @@
       }
     },
     {
-      "identity" : "grpc-ios",
+      "identity" : "grpc-binary",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/grpc/grpc-ios.git",
+      "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "8440b914756e0d26d4f4d054a1c1581daedfc5b6",
-        "version" : "1.44.3-grpc"
+        "revision" : "df37f6af8a273bc687e3166843ed86007de57d78",
+        "version" : "1.44.0"
       }
     },
     {
@@ -95,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "4e9bbf2808b8fee444e84a48f5f3c12641987d3e",
-        "version" : "1.7.2"
+        "revision" : "5ccda3981422a84186387dbb763ba739178b529c",
+        "version" : "2.3.0"
       }
     },
     {
@@ -104,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GTMAppAuth.git",
       "state" : {
-        "revision" : "b9d1683be336ba8c8d1c6867bafeb056a5399700",
-        "version" : "1.3.0"
+        "revision" : "6dee0cde8a1b223737a5159e55e6b4ec16bbbdd9",
+        "version" : "1.3.1"
       }
     },
     {

--- a/fairer-iOS/fairer-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -179,6 +179,15 @@
         "revision" : "0af9125c4eae12a4973fb66574c53a54962a9e1e",
         "version" : "1.21.0"
       }
+    },
+    {
+      "identity" : "swiftsvg",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mchoe/SwiftSVG",
+      "state" : {
+        "branch" : "master",
+        "revision" : "88b9ee086b29019e35f6f49c8e30e5552eb8fa9d"
+      }
     }
   ],
   "version" : 2

--- a/fairer-iOS/fairer-iOS/Global/Extension/String+Extension.swift
+++ b/fairer-iOS/fairer-iOS/Global/Extension/String+Extension.swift
@@ -123,5 +123,11 @@ extension String {
             return ""
         }
     }
+    
+    func subString(from: Int, to: Int) -> String {
+        let startIndex = self.index(self.startIndex, offsetBy: from)
+        let endIndex = self.index(self.startIndex, offsetBy: to)
+        return String(self[startIndex...endIndex])
+    }
 }
 

--- a/fairer-iOS/fairer-iOS/Global/Extension/UIImageView+Extension.swift
+++ b/fairer-iOS/fairer-iOS/Global/Extension/UIImageView+Extension.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 extension UIImageView {
-    func load(from url: String) {
+    func loadURL(from url: String) {
         
         let cacheKey = NSString(string: url)
         if let cachedImage = ImageCacheManager.shared.object(forKey: cacheKey) {
@@ -27,6 +27,30 @@ extension UIImageView {
                     }
                 }
             }
+        }
+    }
+    
+    func load(from url: String) {
+        let firstImageURL = url.components(separatedBy: "Fic_")[1]
+        let finalImageURL = firstImageURL.components(separatedBy: ".svg")[0]
+        switch finalImageURL {
+        case "profile1": self.image = ImageLiterals.profileBlue3
+        case "profile2": self.image = ImageLiterals.profileBlue4
+        case "profile3": self.image = ImageLiterals.profilePink1
+        case "profile4": self.image = ImageLiterals.profileOrange1
+        case "profile5": self.image = ImageLiterals.profilePink3
+        case "profile6": self.image = ImageLiterals.profilePurple1
+        case "profile7": self.image = ImageLiterals.profilePurple2
+        case "profile8": self.image = ImageLiterals.profilePurple3
+        case "profile9": self.image = ImageLiterals.profileOrange2
+        case "profile10": self.image = ImageLiterals.profileYellow2
+        case "profile11": self.image = ImageLiterals.profileIndigo3
+        case "profile12": self.image = ImageLiterals.profileGreen1
+        case "profile13": self.image = ImageLiterals.profileYellow1
+        case "profile14": self.image = ImageLiterals.profileGreen3
+        case "profile15": self.image = ImageLiterals.profileLightBlue1
+        case "profile16": self.image = ImageLiterals.profileLightBlue2
+        default: return
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Global/Supports/Info.plist
+++ b/fairer-iOS/fairer-iOS/Global/Supports/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<false/>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
@@ -58,6 +58,7 @@ final class LoginViewController: BaseViewController {
     // MARK: - lifecycle
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         self.setButtonAction()
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
@@ -62,6 +62,10 @@ final class LoginViewController: BaseViewController {
         self.setButtonAction()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        setupNavigationBar()
+    }
+    
     override func configUI() {
         view.backgroundColor = .blue
     }
@@ -94,11 +98,16 @@ final class LoginViewController: BaseViewController {
         }
     }
     
-    // MARK: - helper func
+    // MARK: - func
     
     override func setupNavigationBar() {
+        guard let navigationBar = navigationController?.navigationBar else { return }
         let appearance = UINavigationBarAppearance()
+        appearance.shadowColor = .clear
         appearance.backgroundColor = .blue
+        navigationBar.standardAppearance = appearance
+        navigationBar.compactAppearance = appearance
+        navigationBar.scrollEdgeAppearance = appearance
     }
 
     private func googleSignIn() {

--- a/fairer-iOS/fairer-iOS/Screens/Auth/OnboardingName/OnboardingNameViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/OnboardingName/OnboardingNameViewController.swift
@@ -111,26 +111,29 @@ final class OnboardingNameViewController: BaseViewController {
         })
     }
     
+    @objc func textDidChange(noti: NSNotification) {
+        if let text = nameTextField.text {
+            if text.count >= nameMaxLength {
+                let fixedText = text.subString(from: 0, to: nameMaxLength - 1)
+                nameTextField.text = fixedText
+                let when = DispatchTime.now() + 0.01
+                DispatchQueue.main.asyncAfter(deadline: when) {
+                    self.nameTextField.text = fixedText
+                }
+            }
+        }
+    }
+    
     private func setupNotificationCenter() {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(textDidChange), name: UITextField.textDidChangeNotification, object: nil)
     }
 }
 
 // MARK: - extension
 
 extension OnboardingNameViewController : UITextFieldDelegate {
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        if let char = string.cString(using: String.Encoding.utf8) {
-            let isBackSpace = strcmp(char, "\\b")
-            if isBackSpace == -92 {
-                return true
-            }
-        }
-        guard textField.text!.count < 5 else { return false }
-        return true
-    }
-    
     func textFieldDidChangeSelection(_ textField: UITextField) {
         let hasText = nameTextField.hasText
         nameDoneButton.isDisabled = !hasText

--- a/fairer-iOS/fairer-iOS/Screens/Auth/OnboardingName/OnboardingNameViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/OnboardingName/OnboardingNameViewController.swift
@@ -44,8 +44,11 @@ final class OnboardingNameViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupDelegation()
-        setupNotificationCenter()
         setButtonAction()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        setupNotificationCenter()
     }
     
     override func configUI() {

--- a/fairer-iOS/fairer-iOS/Screens/Group/GroupMain/GroupMainViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/GroupMain/GroupMainViewController.swift
@@ -74,6 +74,7 @@ final class GroupMainViewController: BaseViewController {
     // MARK: - life cycle
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         setButtonAction()
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/Group/HouseInfo/ViewController/HouseInfoViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/HouseInfo/ViewController/HouseInfoViewController.swift
@@ -56,6 +56,7 @@ final class HouseInfoViewController: BaseViewController {
     // MARK: - lifecycle
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         setButtonAction()
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/Group/HouseInviteCode/ViewController/HouseInviteCodeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/HouseInviteCode/ViewController/HouseInviteCodeViewController.swift
@@ -87,17 +87,18 @@ final class HouseInviteCodeViewController: BaseViewController {
     
     // MARK: - lifecycle
     
-    override func configUI() {
-        super.configUI()
-    }
-    
     override func viewDidLoad() {
+        super.viewDidLoad()
         setButtonAction()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         getinviteCodeExpirationDateTime()
+    }
+    
+    override func configUI() {
+        super.configUI()
     }
     
     override func render() {

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/DailyCollectionView/CalendarDailyTableViewCell.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/DailyCollectionView/CalendarDailyTableViewCell.swift
@@ -13,7 +13,11 @@ final class CalendarDailyTableViewCell: BaseTableViewCell {
     
     static let identifier = "CellId"
     
-    lazy var memberListProfilePath = [Assignee]()
+    lazy var memberListProfilePath = [Assignee]() {
+        didSet {
+            workerCollectionView.reloadData()
+        }
+    }
     
     private enum Size {
         static let collectionHorizontalSpacing: CGFloat = 0
@@ -176,7 +180,9 @@ extension CalendarDailyTableViewCell: UICollectionViewDataSource {
             assert(false, "Wrong Cell")
             return UICollectionViewCell()
         }
-        cell.workerIconImage.load(from: self.memberListProfilePath[indexPath.row].profilePath ?? String())
+        if let profile = self.memberListProfilePath[indexPath.row].profilePath {
+            cell.workerIconImage.load(from: profile)
+        }
         return cell
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/HomeGroupView/HomeGroupCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/HomeGroupView/HomeGroupCollectionView.swift
@@ -85,8 +85,10 @@ extension HomeGroupCollectionView: UICollectionViewDataSource {
             assert(false, "Wrong Cell")
             return UICollectionViewCell()
         }
-        cell.titleLabel.text = userList[indexPath.item].memberName
-        cell.titleImage.load(from: userList[indexPath.item].profilePath ?? String())
+        guard let memberName = userList[indexPath.item].memberName,
+              let memberImage = userList[indexPath.item].profilePath else { return UICollectionViewCell() }
+        cell.titleImage.load(from: memberImage)
+        cell.titleLabel.text = memberName
         if cell.isSelected == true { cell.onSelected() }
         else { cell.onDeselected() }
         return cell

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -148,7 +148,6 @@ final class HomeViewController: BaseViewController {
         self.setupDelegate()
         self.setWeekCalendarSwipeGesture()
         self.setDatePicker()
-        self.setNotification()
         self.setButtonEvent()
     }
     
@@ -170,6 +169,7 @@ final class HomeViewController: BaseViewController {
         }
         self.getRules()
         self.getMyInfo()
+        self.setNotification()
     }
     
     override func configUI() {
@@ -348,11 +348,10 @@ final class HomeViewController: BaseViewController {
     private func setHomeRuleLabel() {
         var index = 0
         guard let rules = ruleArray else {
-            print("out!!!")
             homeRuleView.homeRuleDescriptionLabel.text = TextLiteral.homeRuleViewRuleDescriptionLabel
             return
         }
-        if rules.count == 0 {
+        if self.ruleArray?.isEmpty == true {
             homeRuleView.homeRuleDescriptionLabel.text = TextLiteral.homeRuleViewRuleDescriptionLabel
             return
         }
@@ -567,7 +566,7 @@ final class HomeViewController: BaseViewController {
         guard let lastDateInFullDateList = self.homeWeekCalendarCollectionView.fullDateList.last else { return }
         var doneWorkSum: Int = 0
         DispatchQueue.main.async {
-            LoadingView.showLoading()
+            self.view.isUserInteractionEnabled = false
         }
         DispatchQueue.global().async {
             if isOwn {
@@ -579,7 +578,7 @@ final class HomeViewController: BaseViewController {
                         return
                     }
                     DispatchQueue.main.async {
-                        LoadingView.hideLoading()
+                        self.view.isUserInteractionEnabled = true
                         self.homeWeekCalendarCollectionView.countWorkLeftWeekCalendar = [Int]()
                         self.homeWeekCalendarCollectionView.dotList = [UIImage]()
                         for date in self.homeWeekCalendarCollectionView.fullDateList {
@@ -613,7 +612,7 @@ final class HomeViewController: BaseViewController {
                         return
                     }
                     DispatchQueue.main.async {
-                        LoadingView.hideLoading()
+                        self.view.isUserInteractionEnabled = true
                         self.homeWeekCalendarCollectionView.countWorkLeftWeekCalendar = [Int]()
                         self.homeWeekCalendarCollectionView.dotList = [UIImage]()
                         for date in self.homeWeekCalendarCollectionView.fullDateList {

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -12,7 +12,12 @@ import SnapKit
 final class HomeViewController: BaseViewController {
     
     private var teamId: Int?
-    private var ruleArray: [RuleData]?
+    private var ruleArray: [RuleData]? {
+        didSet {
+            self.ruleArrayIndex = 0
+        }
+    }
+    private var ruleArrayIndex = 0
     private var isScrolled = false
     private lazy var leftSwipeGestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(handleSwipes(_:)))
     private lazy var rightSwipeGestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(handleSwipes(_:)))
@@ -149,6 +154,7 @@ final class HomeViewController: BaseViewController {
         self.setWeekCalendarSwipeGesture()
         self.setDatePicker()
         self.setButtonEvent()
+        self.setHomeRuleLabel()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -311,6 +317,26 @@ final class HomeViewController: BaseViewController {
         homeWeekCalendarCollectionView.addGestureRecognizer(rightSwipeGestureRecognizer)
     }
     
+    private func setHomeRuleLabel() {
+        if ruleArray?.isEmpty == true {
+            homeRuleView.homeRuleDescriptionLabel.text = TextLiteral.homeRuleViewRuleDescriptionLabel
+        } else {
+            homeRuleView.homeRuleDescriptionLabel.text = ruleArray?[self.ruleArrayIndex].ruleName
+        }
+        Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
+            guard let count = self?.ruleArray?.count else { return }
+            if self?.ruleArray?.isEmpty == true {
+                self?.homeRuleView.homeRuleDescriptionLabel.text = TextLiteral.homeRuleViewRuleDescriptionLabel
+            } else {
+                self?.homeRuleView.homeRuleDescriptionLabel.text = self?.ruleArray?[self?.ruleArrayIndex ?? Int()].ruleName
+                self?.ruleArrayIndex += 1
+                if self?.ruleArrayIndex ?? Int() > count - 1 {
+                    self?.ruleArrayIndex = 0
+                }
+            }
+        }
+    }
+    
     private func setDatePicker() {
         datePickerView.isHidden = true
         datePickerView.dismissClosure = { [weak self] pickedDate, startDateWeek, yearInString, monthInString in
@@ -344,27 +370,6 @@ final class HomeViewController: BaseViewController {
     }
     
     // MARK: - func
-    
-    private func setHomeRuleLabel() {
-        var index = 0
-        guard let rules = ruleArray else {
-            homeRuleView.homeRuleDescriptionLabel.text = TextLiteral.homeRuleViewRuleDescriptionLabel
-            return
-        }
-        if self.ruleArray?.isEmpty == true {
-            homeRuleView.homeRuleDescriptionLabel.text = TextLiteral.homeRuleViewRuleDescriptionLabel
-            return
-        }
-        homeRuleView.homeRuleDescriptionLabel.text = rules[index].ruleName
-        Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
-            guard let count = self?.ruleArray?.count else { return }
-            self?.homeRuleView.homeRuleDescriptionLabel.text = self?.ruleArray?[index].ruleName
-            index += 1
-            if index > count - 1 {
-                index = 0
-            }
-        }
-    }
     
     private func getDivideIndex() {
         self.divideIndex = 0
@@ -525,7 +530,15 @@ final class HomeViewController: BaseViewController {
                 return
             }
             self.ruleArray = response.ruleResponseDtos
-            self.setHomeRuleLabel()
+            self.setHomeRuleLableAfterSettingRules()
+        }
+    }
+    
+    private func setHomeRuleLableAfterSettingRules() {
+        if ruleArray?.isEmpty == true {
+            homeRuleView.homeRuleDescriptionLabel.text = TextLiteral.homeRuleViewRuleDescriptionLabel
+        } else {
+            homeRuleView.homeRuleDescriptionLabel.text = ruleArray?[self.ruleArrayIndex].ruleName
         }
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -703,12 +703,12 @@ final class HomeViewController: BaseViewController {
 
 extension HomeViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        if scrollView.contentOffset.y > 0.1 {
+        if scrollView.contentOffset.y > 2 {
             if isScrolled == false {
                 scrollDidStart()
                 isScrolled = true
             }
-        } else {
+        } else if scrollView.contentOffset.y < 0 {
             scrollDidEnd()
             isScrolled = false
         }

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -645,7 +645,8 @@ final class HomeViewController: BaseViewController {
     
     @objc func observeWeekCalendar(notification: Notification) {
         guard let object = notification.userInfo?[NotificationKey.date] as? String else { return }
-        
+        let dateArray = object.split(separator: ".")
+        self.homeCalenderView.calendarMonthLabelButton.setTitle("\(dateArray[0])년 \(dateArray[1])월", for: .normal)
         self.getHouseWorksByDate (
             isOwn: self.checkMemeberCellIsOwn(),
             startDate: object,
@@ -946,7 +947,6 @@ extension HomeViewController {
     
     @objc
     private func addTapGesture() {
-
         let selectHouseWorkView = SelectHouseWorkViewController()
         self.navigationController?.pushViewController(selectHouseWorkView, animated: true)
     }

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -754,7 +754,9 @@ extension HomeViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // MARK: - 집안일 수정 뷰로 이동
+        // MARK: - fix me, houseWorks 빈배열 대체
+        let editHouseWorkView = WriteHouseWorkViewController(houseWorks: [])
+        self.navigationController?.pushViewController(editHouseWorkView, animated: true)
     }
 }
 extension HomeViewController: UITableViewDataSource {


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #157 

## 👩‍💻 Contents & Screenshot
<!-- 작업 내용과 이미지를 첨부해주세요. -->
Bug ID | View | Detail | Importance | Finished?
-- | -- | -- | -- | --
1 | LoginVC | 로그인 페이지에서 소셜 로그인 이후 뒤로 돌아가는 백버튼 클릭 시 상단 네비게이션 바 부분 색이 하얀색으로 바뀐다. | p1 | finished!
2 | OnboardingVC | 글자 수가 5개가 되었을 때, 마지막 글자가 완성되지 않는다. | p2 | finished!
3 | UIImage | 전체적으로 이미지 로드 안됨 | p1 | finished!
6 | HomeVC 주간 캘린더 | 주간 캘린더의 터치 이벤트로 ‘월’이 변경 되었을 경우 datepicker 날짜 처리 | p2 | finished!
7 | HomeVC 스크롤 | 홈뷰의 하단 테이블 뷰가 특정 사이즈 이상이 되지 않은 경우, 스크롤 이벤트가 적용되지 않음 | p3 | finished!
8 | HomeVC 규칙 | 규칙 설정 뷰에서 가장 상단의 규칙을 삭제 후 홈뷰로 pop 할 경우 인덱스 참조 에러 남 | p1 | finished!
9 | HomeVC 주간 캘린더 | 다른 뷰로 push 되고 pop 되어 다시 홈뷰로 들어왔을 때, 주간 캘린더 셀 터치로 api 호출 안됨 | p1 | finished!
10 | Navigation | Navigation Controller pop 되었을 때 다음 push가 두번됨 | p1 | finished!

1. 노션 페이지에 iOS, 버그 테이블 작성 이후 위의 1, 2, 3, 6, 7, 8, 9, 10 Bug ID를 디버깅했습니다.
2. UIImageView에 기존 load 함수의 이름을 loadURL로 바꾸고 url string을 파싱하여 asset에 매칭하는 방법이 적용된 함수 이름을 load라고 하였습니다.
3. HomeVC에 하단 집안일 테이블 뷰의 스크롤 이벤트를 수정하였습니다. 기존에는 데이터가 없거나 적을 때에는 스크롤 이벤트를 막았지만, 셀이 3개일 때 스크롤 이벤트가 정상 작동하지 않는 버그를 해결하면서 하단 스크롤이 시작 되었을 때 상단 뷰 height이 0으로 만들고 뷰의 최상단에 도달했을 때 다시 기존 height으로 되돌립니다.
4. OnboardingVC에서 글자 수를 5개로 한정시키고 있었지만 기존 로직은 알파벳만 적용되고 한글에서는 마지막 글자 모음이 표시되지 않은 버그가 있어 NotificationCenter를 추가하는 방식으로 해결했습니다.
5. 기존 로직은 navigation 연결을 위해 button Action 추가 함수를 viewWillAppear에서 호출하며 중복 호출되고 있어 중복 push 되던 버그를 viewDidAppear에서 함수를 호출하여 해결했습니다.
6. 기존 firebase spm을 지우고, "동적링크" "Messaging" 기능 이외의 firebase 기능을 제외하고 다시 추가하였습니다. 이후 개발될 "Messaging" 기능을 수동 설정하기 위해 info.plist 에 FirebaseAppDelegateProxyEnabled를 추가하여 false 설정해두었습니다.

## 📌 Review Point
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- 리뷰하며 발견되는 새로운 버그는 노션 버그 테이블에 업데이트 해주시면 좋을것 같아요!
