### PR TITLE
[ADD] Setting ViewController - 프로필 재설정, 이미지 재설정 구현

### DIFF
--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -1512,7 +1512,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.ios.fairer;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ios.fairer1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -1539,7 +1539,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.ios.fairer;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ios.fairer1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -158,6 +158,8 @@
 		91AF387929E9DA73000C4EFD /* FirebaseDynamicLinks in Frameworks */ = {isa = PBXBuildFile; productRef = 91AF387829E9DA73000C4EFD /* FirebaseDynamicLinks */; };
 		91AF387B29E9DA73000C4EFD /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 91AF387A29E9DA73000C4EFD /* FirebaseMessaging */; };
 		91CB591C29977B09002A3295 /* PickDateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91CB591B29977B09002A3295 /* PickDateView.swift */; };
+		91D4185629EDBF9F00EC2786 /* MemberPatchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D4185529EDBF9F00EC2786 /* MemberPatchRequest.swift */; };
+		91D4185829EDC18200EC2786 /* MemberPatchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D4185729EDC18200EC2786 /* MemberPatchResponse.swift */; };
 		91D6870629E7DCC90046AAA8 /* UINavigationController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D6870529E7DCC90046AAA8 /* UINavigationController+Extension.swift */; };
 		91D6A0C629AE2BFA0051FFE2 /* AuthResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D6A0C529AE2BFA0051FFE2 /* AuthResponse.swift */; };
 		91F9886429B49518008D7AB7 /* WorkInfoReponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91F9886329B49518008D7AB7 /* WorkInfoReponse.swift */; };
@@ -313,6 +315,8 @@
 		917D8B8129A6355500E26B73 /* FCMRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMRouter.swift; sourceTree = "<group>"; };
 		917D8B8729A63AA500E26B73 /* FcmAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FcmAPI.swift; sourceTree = "<group>"; };
 		91CB591B29977B09002A3295 /* PickDateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickDateView.swift; sourceTree = "<group>"; };
+		91D4185529EDBF9F00EC2786 /* MemberPatchRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberPatchRequest.swift; sourceTree = "<group>"; };
+		91D4185729EDC18200EC2786 /* MemberPatchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberPatchResponse.swift; sourceTree = "<group>"; };
 		91D6870529E7DCC90046AAA8 /* UINavigationController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Extension.swift"; sourceTree = "<group>"; };
 		91D6A0C529AE2BFA0051FFE2 /* AuthResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AuthResponse.swift; path = "fairer-iOS/Network/AuthResponse.swift"; sourceTree = SOURCE_ROOT; };
 		91F9886329B49518008D7AB7 /* WorkInfoReponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkInfoReponse.swift; sourceTree = "<group>"; };
@@ -1117,6 +1121,8 @@
 				914C69CF29AA2F7F008EA9EE /* HouseWorkCompleteResponse.swift */,
 				91F9886329B49518008D7AB7 /* WorkInfoReponse.swift */,
 				5A4E711129BEF88B003FD32F /* BlankResponse.swift */,
+				91D4185529EDBF9F00EC2786 /* MemberPatchRequest.swift */,
+				91D4185729EDC18200EC2786 /* MemberPatchResponse.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -1298,6 +1304,7 @@
 				5A8400F029C9B75A00C569E9 /* AddTeamResponse.swift in Sources */,
 				5204AABF2950BE43002FB6CA /* SettingInquiryCellView.swift in Sources */,
 				5A6AAF1929E2A0970055BEE8 /* SettingInviteCodeViewController.swift in Sources */,
+				91D4185829EDC18200EC2786 /* MemberPatchResponse.swift in Sources */,
 				39EEF66F28CBB5A600437654 /* NSObject+Extension.swift in Sources */,
 				52E4C08E297D06F5002AC755 /* SelectManagerCollectionView.swift in Sources */,
 				5A4E711229BEF88B003FD32F /* BlankResponse.swift in Sources */,
@@ -1331,6 +1338,7 @@
 				7EFAA87328DA088900737DF0 /* SelectHouseWorkSpaceCollectionViewCell.swift in Sources */,
 				5227555028B219DC0080DD65 /* AppDelegate.swift in Sources */,
 				52C09CEF29113D3800B46F15 /* HouseMemberCollectionViewCell.swift in Sources */,
+				91D4185629EDBF9F00EC2786 /* MemberPatchRequest.swift in Sources */,
 				5204AACE296C647A002FB6CA /* SelectHouseWorkDetailCollectionViewCell.swift in Sources */,
 				5275397C28EC7619002D8280 /* HouseInviteCodeViewController.swift in Sources */,
 				52C09CED29113D3500B46F15 /* HouseMemberCollectionView.swift in Sources */,

--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -1512,7 +1512,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.ios.fairer1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ios.fairer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -1539,7 +1539,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.ios.fairer1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ios.fairer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/fairer-iOS/fairer-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -179,15 +179,6 @@
         "revision" : "0af9125c4eae12a4973fb66574c53a54962a9e1e",
         "version" : "1.21.0"
       }
-    },
-    {
-      "identity" : "swiftsvg",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mchoe/SwiftSVG",
-      "state" : {
-        "branch" : "master",
-        "revision" : "88b9ee086b29019e35f6f49c8e30e5552eb8fa9d"
-      }
     }
   ],
   "version" : 2

--- a/fairer-iOS/fairer-iOS/Global/Extension/String+Extension.swift
+++ b/fairer-iOS/fairer-iOS/Global/Extension/String+Extension.swift
@@ -5,7 +5,7 @@
 //  Created by Mingwan Choi on 2022/09/10.
 //
 
-import Foundation
+import UIKit
 
 extension String {
     var stringToDate: Date? {
@@ -128,6 +128,28 @@ extension String {
         let startIndex = self.index(self.startIndex, offsetBy: from)
         let endIndex = self.index(self.startIndex, offsetBy: to)
         return String(self[startIndex...endIndex])
+    }
+    
+    func profileAssetStringToString(imageAssetString: String) -> String {
+        switch imageAssetString {
+        case "profileblue3": return TextLiteral.profileImageURL[0]
+        case "profileblue4": return TextLiteral.profileImageURL[1]
+        case "profilepink1": return TextLiteral.profileImageURL[2]
+        case "profileorange1": return TextLiteral.profileImageURL[3]
+        case "profilepink3": return TextLiteral.profileImageURL[4]
+        case "profilepurple1": return TextLiteral.profileImageURL[5]
+        case "profilepurple2": return TextLiteral.profileImageURL[6]
+        case "profilepurple3": return TextLiteral.profileImageURL[7]
+        case "profileorange2": return TextLiteral.profileImageURL[8]
+        case "profileyellow2": return TextLiteral.profileImageURL[9]
+        case "profileindigo3": return TextLiteral.profileImageURL[10]
+        case "profilegreen1": return TextLiteral.profileImageURL[11]
+        case "profileyellow1": return TextLiteral.profileImageURL[12]
+        case "profilegreen3": return TextLiteral.profileImageURL[13]
+        case "profilelightblue1": return TextLiteral.profileImageURL[14]
+        case "profilelightblue2": return TextLiteral.profileImageURL[15]
+        default: return String()
+        }
     }
 }
 

--- a/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
+++ b/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
@@ -200,4 +200,25 @@ enum TextLiteral {
     static let settingProfileViewControllerProfileNameLabel = "이름"
     static let settingProfileViewControllerProfileStatusLabel = "상태 메세지"
     static let settingProfileViewControllerPlaceholderText = "Text"
+    
+    // MARK: - profileImageURLString
+    
+    static let profileImageURL = [
+        "https://firebasestorage.googleapis.com/v0/b/fairer-def59.appspot.com/o/fairer-profile-images%2Fic_profile1.svg?alt=media&token=13ef5688-3e56-452d-9c63-763958427674",
+            "https://firebasestorage.googleapis.com/v0/b/fairer-def59.appspot.com/o/fairer-profile-images%2Fic_profile2.svg?alt=media&token=b2f227e2-ac83-44f3-b143-b04a180f1b89",
+            "https://firebasestorage.googleapis.com/v0/b/fairer-def59.appspot.com/o/fairer-profile-images%2Fic_profile3.svg?alt=media&token=fedfeb3c-6fc2-4752-9039-cb6b2534051b",
+            "https://firebasestorage.googleapis.com/v0/b/fairer-def59.appspot.com/o/fairer-profile-images%2Fic_profile4.svg?alt=media&token=5123ceb8-510c-4de0-bb2e-d665ec24b73c",
+            "https://firebasestorage.googleapis.com/v0/b/fairer-def59.appspot.com/o/fairer-profile-images%2Fic_profile5.svg?alt=media&token=f67556cc-3b5d-4845-b94f-5111263c1028",
+            "https://firebasestorage.googleapis.com/v0/b/fairer-def59.appspot.com/o/fairer-profile-images%2Fic_profile6.svg?alt=media&token=109542ce-1d5d-4edb-ac24-72a82160e87a",
+            "https://firebasestorage.googleapis.com/v0/b/fairer-def59.appspot.com/o/fairer-profile-images%2Fic_profile7.svg?alt=media&token=88fefe28-e14b-41d1-bc1a-002865e06238",
+            "https://firebasestorage.googleapis.com/v0/b/fairer-def59.appspot.com/o/fairer-profile-images%2Fic_profile8.svg?alt=media&token=6cef2c48-444e-42d1-86ae-9328a62799c5",
+            "https://firebasestorage.googleapis.com/v0/b/fairer-def59.appspot.com/o/fairer-profile-images%2Fic_profile9.svg?alt=media&token=cbf5c429-2376-49e0-8aee-99ca60efc526",
+            "https://firebasestorage.googleapis.com/v0/b/fairer-def59.appspot.com/o/fairer-profile-images%2Fic_profile10.svg?alt=media&token=79107fe2-e40a-4984-9438-a44eafd90b5a",
+            "https://firebasestorage.googleapis.com/v0/b/fairer-def59.appspot.com/o/fairer-profile-images%2Fic_profile11.svg?alt=media&token=995e5a46-083c-4210-902b-aabe1ce382d6",
+            "https://firebasestorage.googleapis.com/v0/b/fairer-def59.appspot.com/o/fairer-profile-images%2Fic_profile12.svg?alt=media&token=0020c59b-1720-4ff0-8efd-33f77291059a",
+            "https://firebasestorage.googleapis.com/v0/b/fairer-def59.appspot.com/o/fairer-profile-images%2Fic_profile13.svg?alt=media&token=208314f3-a68a-4810-b801-dbe67f60b57b",
+            "https://firebasestorage.googleapis.com/v0/b/fairer-def59.appspot.com/o/fairer-profile-images%2Fic_profile14.svg?alt=media&token=3770dc20-ac27-46d4-9ea4-125271b35b60",
+            "https://firebasestorage.googleapis.com/v0/b/fairer-def59.appspot.com/o/fairer-profile-images%2Fic_profile15.svg?alt=media&token=d4929be9-5882-4bfa-8f1f-58aeffa1888a",
+            "https://firebasestorage.googleapis.com/v0/b/fairer-def59.appspot.com/o/fairer-profile-images%2Fic_profile16.svg?alt=media&token=decb7b05-6c49-40f1-af43-13eb69220188"
+    ]
 }

--- a/fairer-iOS/fairer-iOS/Global/Supports/Info.plist
+++ b/fairer-iOS/fairer-iOS/Global/Supports/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>FirebaseAppDelegateProxyEnabled</key>
-	<false/>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -15,6 +13,8 @@
 			</array>
 		</dict>
 	</array>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<false/>
 	<key>GIDClientID</key>
 	<string>2.</string>
 	<key>GIDServerClientID</key>

--- a/fairer-iOS/fairer-iOS/Network/DTO/MemberPatchRequest.swift
+++ b/fairer-iOS/fairer-iOS/Network/DTO/MemberPatchRequest.swift
@@ -1,0 +1,14 @@
+//
+//  MemberPatchRequest.swift
+//  fairer-iOS
+//
+//  Created by 홍준혁 on 2023/04/18.
+//
+
+import Foundation
+
+struct MemberPatchRequest: Codable, Equatable {
+    let memberName: String?
+    let profilePath: String?
+    let statusMessage: String?
+}

--- a/fairer-iOS/fairer-iOS/Network/DTO/MemberPatchRequest.swift
+++ b/fairer-iOS/fairer-iOS/Network/DTO/MemberPatchRequest.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct MemberPatchRequest: Codable, Equatable {
-    let memberName: String?
-    let profilePath: String?
-    let statusMessage: String?
+    var memberName: String?
+    var profilePath: String?
+    var statusMessage: String?
 }

--- a/fairer-iOS/fairer-iOS/Network/DTO/MemberPatchRequest.swift
+++ b/fairer-iOS/fairer-iOS/Network/DTO/MemberPatchRequest.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct MemberPatchRequest: Codable, Equatable {
-    var memberName: String?
-    var profilePath: String?
-    var statusMessage: String?
+    let memberName: String?
+    let profilePath: String?
+    let statusMessage: String?
 }

--- a/fairer-iOS/fairer-iOS/Network/DTO/MemberPatchResponse.swift
+++ b/fairer-iOS/fairer-iOS/Network/DTO/MemberPatchResponse.swift
@@ -1,0 +1,13 @@
+//
+//  MemberPatchResponse.swift
+//  fairer-iOS
+//
+//  Created by 홍준혁 on 2023/04/18.
+//
+
+import Foundation
+
+struct MemberPatchResponse: Codable, Equatable {
+    let code: Int?
+    let message: String?
+}

--- a/fairer-iOS/fairer-iOS/Network/Router/MembersRouter.swift
+++ b/fairer-iOS/fairer-iOS/Network/Router/MembersRouter.swift
@@ -9,7 +9,7 @@ import Moya
 
 enum MemberRouter {
     case getmemberInfo
-
+    case petchMemberInfo(body: MemberPatchRequest)
 }
 
 extension MemberRouter: BaseTargetType {
@@ -17,6 +17,8 @@ extension MemberRouter: BaseTargetType {
         switch self {
         case .getmemberInfo:
             return URLConstant.members + "/me"
+        case .petchMemberInfo:
+            return URLConstant.members
         }
     }
     
@@ -24,6 +26,8 @@ extension MemberRouter: BaseTargetType {
         switch self {
         case .getmemberInfo:
             return .get
+        case .petchMemberInfo:
+            return .patch
         }
     }
     
@@ -31,6 +35,8 @@ extension MemberRouter: BaseTargetType {
         switch self {
         case .getmemberInfo:
             return .requestPlain
+        case .petchMemberInfo(let body):
+            return .requestJSONEncodable(body)
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/Auth/OnboardingProfile/ViewController/OnboardingProfileViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/OnboardingProfile/ViewController/OnboardingProfileViewController.swift
@@ -34,8 +34,8 @@ class OnboardingProfileViewController: BaseViewController {
         label.textColor = .gray600
         return label
     }()
-    private let onboardingProfileGroupCollectionView = OnboardingProfileGroupCollectionView()
-    private lazy var profileDoneButton: MainButton = {
+    let onboardingProfileGroupCollectionView = OnboardingProfileGroupCollectionView()
+    lazy var profileDoneButton: MainButton = {
         let button = MainButton()
         button.title = TextLiteral.onboardingProfileViewControllerDoneButtonText
         button.isDisabled = true
@@ -108,7 +108,7 @@ class OnboardingProfileViewController: BaseViewController {
         navigationItem.leftBarButtonItem = backButton
     }
     
-    private func didTapImage() {
+    func didTapImage() {
         onboardingProfileGroupCollectionView.didTappedImage = { [weak self] image in
             self?.selectedProfileImageView.image = image
             guard let selectedImage = self?.selectedProfileImageView.image else { return }

--- a/fairer-iOS/fairer-iOS/Screens/ProfileImageButtonView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/ProfileImageButtonView.swift
@@ -19,7 +19,7 @@ final class ProfileImageButtonView: UIButton {
     
     // MARK: - property
     
-    private lazy var profileImageView = UIImageView()
+    lazy var profileImageView = UIImageView()
     private let profileBrushImageView = UIImageView(image: ImageLiterals.settingProfileImageBrushButton)
     
     // MARK: - life cycle

--- a/fairer-iOS/fairer-iOS/Screens/Setting/SettingProfileImage/SettingProfileImageViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Setting/SettingProfileImage/SettingProfileImageViewController.swift
@@ -15,6 +15,7 @@ class SettingProfileImageViewController: OnboardingProfileViewController {
     private var lastProfileImage: String?
     
     var profileImageChangeClosure: ((String) -> Void)?
+    var settingProfileViewDidPop: ((Bool) -> Void)?
     
     // MARK: - life cycle
     
@@ -30,6 +31,11 @@ class SettingProfileImageViewController: OnboardingProfileViewController {
         }
         petchMyInfo()
         self.navigationController?.popViewController(animated: true)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        settingProfileViewDidPop?(true)
     }
     
     override func didTapImage() {

--- a/fairer-iOS/fairer-iOS/Screens/Setting/SettingProfileImage/SettingProfileImageViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Setting/SettingProfileImage/SettingProfileImageViewController.swift
@@ -12,9 +12,9 @@ class SettingProfileImageViewController: OnboardingProfileViewController {
     private var firstProfileImage: String?
     private var firstName: String?
     private var firstStatus: String?
-    
     private var lastProfileImage: String?
     
+    var profileImageChangeClosure: ((String) -> Void)?
     
     // MARK: - life cycle
     
@@ -25,6 +25,9 @@ class SettingProfileImageViewController: OnboardingProfileViewController {
     // MARK: - func
     
     override func didTapDoneButton() {
+        if let lastProfileImage = lastProfileImage {
+            profileImageChangeClosure?(lastProfileImage)
+        }
         petchMyInfo()
         self.navigationController?.popViewController(animated: true)
     }

--- a/fairer-iOS/fairer-iOS/Screens/Setting/SettingProfileImage/SettingProfileImageViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Setting/SettingProfileImage/SettingProfileImageViewController.swift
@@ -8,24 +8,68 @@
 import UIKit
 
 class SettingProfileImageViewController: OnboardingProfileViewController {
-
-    // FIXME: - api 연결로 대체
-    private let lastProfileImage = ImageLiterals.profileBlue3
+    
+    private var firstProfileImage: String?
+    private var firstName: String?
+    private var firstStatus: String?
+    
+    private var lastProfileImage: String?
+    
     
     // MARK: - life cycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupProfileImage()
     }
     
     // MARK: - func
     
-    private func setupProfileImage() {
-        super.selectedProfileImageView.image = lastProfileImage
+    override func didTapDoneButton() {
+        petchMyInfo()
+        self.navigationController?.popViewController(animated: true)
     }
     
-    override func didTapDoneButton() {
-        self.navigationController?.popViewController(animated: true)
+    override func didTapImage() {
+        onboardingProfileGroupCollectionView.didTappedImage = { [weak self] image in
+            self?.selectedProfileImageView.image = image
+            guard let selectedImage = self?.selectedProfileImageView.image else { return }
+            if selectedImage != ImageLiterals.profileNone {
+                self?.profileDoneButton.isDisabled = false
+                if let imageString = image.accessibilityIdentifier {
+                    self?.lastProfileImage = imageString.profileAssetStringToString(imageAssetString: imageString)
+                }
+            }
+        }
+    }
+    
+    func setupProfile(image: String, name: String, status: String) {
+        super.selectedProfileImageView.load(from: image)
+        self.firstProfileImage = image
+        self.firstStatus = status
+        self.firstName = name
+        self.lastProfileImage = image
+    }
+    
+    private func petchMyInfo() {
+        let memberPatchRequest = MemberPatchRequest(memberName: firstName, profilePath: lastProfileImage, statusMessage: firstStatus)
+        self.petchMemberInfoFromServer(body: memberPatchRequest) { [weak self] response in
+            guard self != nil else { return }
+        }
+    }
+}
+
+extension SettingProfileImageViewController {
+    private func petchMemberInfoFromServer(body: MemberPatchRequest, completion: @escaping (MemberPatchResponse) -> Void) {
+        NetworkService.shared.members.petchMemberInfo(body: body) { result in
+            switch result {
+            case .success(let response):
+                guard let data = response as? MemberPatchResponse else { return }
+                completion(data)
+            case .requestErr(let errorResponse):
+                dump(errorResponse)
+            default:
+                print("error")
+            }
+        }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SettingProfileViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SettingProfileViewController.swift
@@ -53,10 +53,6 @@ final class SettingProfileViewController: BaseViewController {
         if let imageString = lastProfileImage {
             profileImageButtonView.profileImageView.load(from: imageString)
         }
-        let action = UIAction { [weak self] _ in
-            self?.pushSettingProfileImageViewController()
-        }
-        profileImageButtonView.addAction(action, for: .touchUpInside)
         return profileImageButtonView
     }()
     private let settingProfileNameLabel: UILabel = {
@@ -120,10 +116,6 @@ final class SettingProfileViewController: BaseViewController {
         let button = MainButton()
         button.isDisabled = true
         button.title = TextLiteral.doneButtonText
-        let action = UIAction {[weak self] _ in
-            self?.didTappedDoneButton()
-        }
-        button.addAction(action, for: .touchUpInside)
         return button
     }()
     
@@ -133,6 +125,7 @@ final class SettingProfileViewController: BaseViewController {
         super.viewDidLoad()
         setupDelegation()
         setupNotificationCenter()
+        setButtomAction()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -210,16 +203,6 @@ final class SettingProfileViewController: BaseViewController {
     private func setupNotificationCenter() {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
-    }
-    
-    private func pushSettingProfileImageViewController() {
-        let settingProfileImageView = SettingProfileImageViewController()
-        self.navigationController?.pushViewController(settingProfileImageView, animated: true)
-    }
-    
-    private func didTappedDoneButton() {
-        self.petchMyInfo()
-        self.navigationController?.popViewController(animated: true)
     }
     
     private func didTappedTextField() {
@@ -315,7 +298,7 @@ final class SettingProfileViewController: BaseViewController {
     }
     
     private func petchMyInfo() {
-        let memberPatchRequest = MemberPatchRequest(memberName: self.lastName, profilePath: self.lastProfileImage, statusMessage: self.lastStatus)
+        let memberPatchRequest = MemberPatchRequest(memberName: lastName, profilePath: lastProfileImage, statusMessage: lastStatus)
         self.petchMemberInfoFromServer(body: memberPatchRequest) { [weak self] response in
             guard self != nil else { return }
         }
@@ -358,6 +341,38 @@ extension SettingProfileViewController: UITextFieldDelegate {
         view.endEditing(true)
     }
 }
+
+// MARK: - set buttom action
+
+extension SettingProfileViewController {
+    private func setButtomAction() {
+        let doneAction = UIAction {[weak self] _ in
+            self?.didTappedDoneButton()
+        }
+        let action = UIAction { [weak self] _ in
+            self?.pushSettingProfileImageViewController()
+        }
+
+        settingProfileDoneButton.addAction(doneAction, for: .touchUpInside)
+        settingProfileButtonView.addAction(action, for: .touchUpInside)
+    }
+    
+    private func didTappedDoneButton() {
+        self.petchMyInfo()
+        self.navigationController?.popViewController(animated: true)
+    }
+    
+    private func pushSettingProfileImageViewController() {
+        let settingProfileImageView = SettingProfileImageViewController()
+        if let image = lastProfileImage,
+           let name = lastName,
+           let status = lastStatus {
+            settingProfileImageView.setupProfile(image: image, name: name, status: status)
+        }
+        self.navigationController?.pushViewController(settingProfileImageView, animated: true)
+    }
+}
+
 
 // MARK: - network
 

--- a/fairer-iOS/fairer-iOS/Screens/SettingProfileViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SettingProfileViewController.swift
@@ -11,6 +11,7 @@ import SnapKit
 
 final class SettingProfileViewController: BaseViewController {
     
+    private var loadFirstTime: Bool = true
     private var firstProfileImage: String?
     private var firstName: String?
     private var firstStatus: String?
@@ -50,9 +51,6 @@ final class SettingProfileViewController: BaseViewController {
     private lazy var settingProfileButtonView: ProfileImageButtonView = {
         let profileImageButtonView = ProfileImageButtonView()
         let UIImageView = UIImageView()
-        if let imageString = lastProfileImage {
-            profileImageButtonView.profileImageView.load(from: imageString)
-        }
         return profileImageButtonView
     }()
     private let settingProfileNameLabel: UILabel = {
@@ -130,7 +128,14 @@ final class SettingProfileViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        getMyInfo()
+        if loadFirstTime == false {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+                self?.getMyInfo()
+            }
+        } else {
+            getMyInfo()
+            loadFirstTime = false
+        }
     }
     
     override func render() {
@@ -368,6 +373,9 @@ extension SettingProfileViewController {
            let name = lastName,
            let status = lastStatus {
             settingProfileImageView.setupProfile(image: image, name: name, status: status)
+        }
+        settingProfileImageView.profileImageChangeClosure = {[weak self] imageString in
+            self?.lastProfileImage = imageString
         }
         self.navigationController?.pushViewController(settingProfileImageView, animated: true)
     }

--- a/fairer-iOS/fairer-iOS/Screens/SettingProfileViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SettingProfileViewController.swift
@@ -11,11 +11,11 @@ import SnapKit
 
 final class SettingProfileViewController: BaseViewController {
     
-    private var loadFirstTime: Bool = true
     private var firstProfileImage: String?
     private var firstName: String?
     private var firstStatus: String?
     
+    private var isSettingProfileViewPoped = false
     private var lastProfileImage: String? {
         didSet {
             if let imageString = lastProfileImage {
@@ -36,7 +36,6 @@ final class SettingProfileViewController: BaseViewController {
     
     private var isNameSatisfied = true
     private var isStatusSatisfied = true
-
     
     // MARK: - property
     
@@ -128,14 +127,14 @@ final class SettingProfileViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        if loadFirstTime == false {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
-                self?.getMyInfo()
-            }
-        } else {
+        if isSettingProfileViewPoped == false {
             getMyInfo()
-            loadFirstTime = false
         }
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        isSettingProfileViewPoped = false
     }
     
     override func render() {
@@ -369,13 +368,16 @@ extension SettingProfileViewController {
     
     private func pushSettingProfileImageViewController() {
         let settingProfileImageView = SettingProfileImageViewController()
-        if let image = lastProfileImage,
-           let name = lastName,
-           let status = lastStatus {
+        if let image = firstProfileImage,
+           let name = firstName,
+           let status = firstStatus {
             settingProfileImageView.setupProfile(image: image, name: name, status: status)
         }
-        settingProfileImageView.profileImageChangeClosure = {[weak self] imageString in
+        settingProfileImageView.profileImageChangeClosure = { [weak self] imageString in
             self?.lastProfileImage = imageString
+        }
+        settingProfileImageView.settingProfileViewDidPop = { [weak self] didPop in
+            self?.isSettingProfileViewPoped = didPop
         }
         self.navigationController?.pushViewController(settingProfileImageView, animated: true)
     }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #162 

## 👩‍💻 Contents & Screenshot
<!-- 작업 내용과 이미지를 첨부해주세요. -->
![Simulator Screen Recording - iPhone 14 - 2023-04-18 at 21 52 33](https://user-images.githubusercontent.com/83629193/232783615-f8d6019c-dcd1-4e4e-80d8-33c37a388329.gif)

- Setting ViewController에서 사용자의 이름과 상태 메세지 수정을 구현
- 사용자의 프로필 이미지 수정 구현

## 📌 Review Point

- SettingProfileImage 뷰에서 프로필 이미지를 재설정하고 프로필 patch api 호출 이후, SettingProfileImage 뷰가 pop되면 SettingProfileViewController 뷰로 넘어가면 재설정한 프로필의 이미지가 로드되어야 하는데 그 과정에서 api 호출 딜레이로 asyncAfter를 사용하지 않으면 변경 전의 이미지가 로드되는 경우가 있었습니다. 
저는 해당 문제를 asyncAfter로 해결했는데 혹시 다른 더 좋은 방법이 있으면 같이 이야기해보아요!

## 🔓 Next Step
<!-- 다음으로 할 일을 적어주세요. -->
- Onboarding View 쪽의 프로필 이미지 설정 api 연결
- 회원탈퇴 기능 구현
