### PR TITLE
[ADD] Onboarding ViewController - 사용자 이름, 프로필 설정 api 연결

### DIFF
--- a/fairer-iOS/fairer-iOS/Screens/Auth/OnboardingName/OnboardingNameViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/OnboardingName/OnboardingNameViewController.swift
@@ -162,7 +162,8 @@ extension OnboardingNameViewController {
             nameTextField.layer.borderWidth = 0
             disableLabel.isHidden = true
             let onBoardingProfileViewController = OnboardingProfileViewController()
-            if let name = nameTextField.text{            onBoardingProfileViewController.setUserName(name: name)
+            if let name = nameTextField.text{
+                onBoardingProfileViewController.setUserName(name: name)
             }
             self.navigationController?.pushViewController(onBoardingProfileViewController, animated: true)
         } else {

--- a/fairer-iOS/fairer-iOS/Screens/Auth/OnboardingName/OnboardingNameViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/OnboardingName/OnboardingNameViewController.swift
@@ -161,11 +161,10 @@ extension OnboardingNameViewController {
         if nameTextField.text!.hasCharacters() {
             nameTextField.layer.borderWidth = 0
             disableLabel.isHidden = true
-            
-            // TODO: - userdefault에 이름 저장
             let onBoardingProfileViewController = OnboardingProfileViewController()
+            if let name = nameTextField.text{            onBoardingProfileViewController.setUserName(name: name)
+            }
             self.navigationController?.pushViewController(onBoardingProfileViewController, animated: true)
-            
         } else {
             nameTextField.layer.borderWidth = 1
             nameTextField.layer.borderColor = UIColor.negative20.cgColor

--- a/fairer-iOS/fairer-iOS/Screens/Auth/OnboardingProfile/ViewController/OnboardingProfileViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/OnboardingProfile/ViewController/OnboardingProfileViewController.swift
@@ -11,6 +11,9 @@ import SnapKit
 
 class OnboardingProfileViewController: BaseViewController {
     
+    private var userName: String?
+    private var userImage: String?
+    
     // MARK: - property
     
     private let backButton = BackButton(type: .system)
@@ -89,12 +92,16 @@ class OnboardingProfileViewController: BaseViewController {
     private func setButtonAction() {
         let didTapDoneAction = UIAction { [weak self] _ in
             self?.didTapDoneButton()
+            self?.petchMyInfo()
         }
         self.profileDoneButton.addAction(didTapDoneAction, for: .touchUpInside)
     }
     
     func didTapDoneButton() {
         let groupMainViewController = GroupMainViewController()
+        if let name = userName {
+            groupMainViewController.setUserName(name: name)
+        }
         self.navigationController?.pushViewController(groupMainViewController, animated: true)
     }
     
@@ -111,9 +118,43 @@ class OnboardingProfileViewController: BaseViewController {
     func didTapImage() {
         onboardingProfileGroupCollectionView.didTappedImage = { [weak self] image in
             self?.selectedProfileImageView.image = image
+            if let imageString = image.accessibilityIdentifier {
+                self?.userImage = imageString.profileAssetStringToString(imageAssetString: imageString)
+            }
             guard let selectedImage = self?.selectedProfileImageView.image else { return }
             if selectedImage != ImageLiterals.profileNone {
                 self?.profileDoneButton.isDisabled = false
+            }
+        }
+    }
+    
+    func setUserName(name: String) {
+        userName = name
+    }
+    
+    private func petchMyInfo() {
+        guard let name = userName,
+              let image = userImage else { return }
+        let memberPatchRequest = MemberPatchRequest(memberName: name, profilePath: image, statusMessage: String())
+        self.petchMemberInfoFromServer(body: memberPatchRequest) { [weak self] response in
+            guard self != nil else { return }
+        }
+    }
+}
+
+// MARK: - network
+
+extension OnboardingProfileViewController {
+    private func petchMemberInfoFromServer(body: MemberPatchRequest, completion: @escaping (MemberPatchResponse) -> Void) {
+        NetworkService.shared.members.petchMemberInfo(body: body) { result in
+            switch result {
+            case .success(let response):
+                guard let data = response as? MemberPatchResponse else { return }
+                completion(data)
+            case .requestErr(let errorResponse):
+                dump(errorResponse)
+            default:
+                print("error")
             }
         }
     }

--- a/fairer-iOS/fairer-iOS/Screens/Group/GroupMain/GroupMainViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/GroupMain/GroupMainViewController.swift
@@ -10,9 +10,17 @@ import UIKit
 import SnapKit
 
 final class GroupMainViewController: BaseViewController {
-
+    
     // MARK: - property
     
+    private var userName: String? {
+        didSet {
+            if let userName = userName {
+                titleLabel.text = "안녕하세요. " + userName + TextLiteral.groupMainViewControllerHouseTitleLabel
+                titleLabel.applyColor(to: userName, with: .blue)
+            }
+        }
+    }
     private let backButton = BackButton()
     private var titleLabel: UILabel = {
         let label = UILabel()
@@ -77,12 +85,7 @@ final class GroupMainViewController: BaseViewController {
         super.viewDidLoad()
         setButtonAction()
     }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        bindGroupMemberInfo()
-    }
-    
+
     override func render() {
         view.addSubview(titleLabel)
         titleLabel.snp.makeConstraints {
@@ -148,30 +151,9 @@ final class GroupMainViewController: BaseViewController {
         navigationItem.largeTitleDisplayMode = .never
         navigationItem.leftBarButtonItem = backButton
     }
-    
-    private func bindGroupMemberInfo() {
-        getMemberInfo { [weak self] data in
-            guard let userName = data.memberName else { return }
 
-            self?.titleLabel.text = "안녕하세요. " + userName + TextLiteral.groupMainViewControllerHouseTitleLabel
-            self?.titleLabel.applyColor(to: userName, with: .blue)
-        }
-    }
-}
-
-extension GroupMainViewController {
-    func getMemberInfo(completion: @escaping (MemberResponse) -> Void) {
-        NetworkService.shared.members.getMemberInfo { result in
-            switch result {
-            case .success(let response):
-                guard let memberData = response as? MemberResponse else { return }
-                completion(memberData)
-            case .requestErr(let error):
-                dump(error)
-            default:
-                print("server Error")
-            }
-        }
+    func setUserName(name: String) {
+        userName = name
     }
 }
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #165 

## 👩‍💻 Contents & Screenshot
<!-- 작업 내용과 이미지를 첨부해주세요. -->
![Simulator Screen Recording - iPhone 14 - 2023-04-20 at 03 01 37](https://user-images.githubusercontent.com/83629193/233161239-016dfe46-dbd5-4de1-bbad-27a283a2872f.gif)

- 소셜 로그인 이후 Onboarding VC에서 사용자 이름과 프로필 받는 부분의 api 연결을 작업했습니다.
- 기존 GroupMainViewController에서 api 호출로 사용자 이름을 받아왔던 부분을 프로퍼티 변수값으로 변경하여 api 호출없이 연결되도록 했습니다. 
