### PR TITLE
[ADD] EditHouseWork에 집안일 수정/삭제 api 연결

### DIFF
--- a/fairer-iOS/fairer-iOS/Network/DTO/HouseWorks/EditHouseWorkRequest.swift
+++ b/fairer-iOS/fairer-iOS/Network/DTO/HouseWorks/EditHouseWorkRequest.swift
@@ -12,7 +12,6 @@ struct EditHouseWorkRequest: Codable, Equatable {
     var houseWorkId: Int?
     var houseWorkName: String?
     var repeatCycle: String?
-    var repeatDayOfWeek: String?
     var repeatEndDate: String?
     var repeatPattern: String?
     var scheduledDate: String?

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/View/RepeatAlertView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/View/RepeatAlertView.swift
@@ -41,6 +41,12 @@ enum RepeatAlertType {
     }
 }
 
+enum ScheduleActionType: String {
+    case once = "O"
+    case here = "H"
+    case all = "A"
+}
+
 final class RepeatAlertView: BaseUIView {
     
     private let tableViewList = TextLiteral.repeatTableViewList
@@ -49,6 +55,8 @@ final class RepeatAlertView: BaseUIView {
             setupAttribute()
         }
     }
+    var actionType: ScheduleActionType?
+    var didTappedActionType: ((ScheduleActionType) -> ())?
     
     // MARK: - property
     
@@ -103,6 +111,7 @@ final class RepeatAlertView: BaseUIView {
         super.init(frame: frame)
         render()
         setCancelButton()
+        setActionButton()
     }
     
     required init?(coder: NSCoder) { nil }
@@ -160,11 +169,34 @@ final class RepeatAlertView: BaseUIView {
         }
         cancelButton.addAction(action, for: .touchUpInside)
     }
+    
+    private func setActionButton() {
+        let action = UIAction { [weak self] _ in
+            if let actionType = self?.actionType {
+                self?.didTappedActionType?(actionType)
+                self?.isHidden = true
+            }
+        }
+        actionButton.addAction(action, for: .touchUpInside)
+    }
 }
 
 // MARK: - extension
 
 extension RepeatAlertView: UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        switch indexPath.item {
+        case 0:
+            actionType = .once
+        case 1:
+            actionType = .here
+        case 2:
+            actionType = .all
+        default:
+            return
+        }
+    }
+    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return tableViewList.count
     }

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/View/RepeatAlertView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/View/RepeatAlertView.swift
@@ -56,7 +56,7 @@ final class RepeatAlertView: BaseUIView {
         }
     }
     var actionType: ScheduleActionType?
-    var didTappedActionType: ((ScheduleActionType) -> ())?
+    var didConfirmActionType: ((ScheduleActionType, RepeatAlertType) -> ())?
     
     // MARK: - property
     
@@ -172,8 +172,8 @@ final class RepeatAlertView: BaseUIView {
     
     private func setActionButton() {
         let action = UIAction { [weak self] _ in
-            if let actionType = self?.actionType {
-                self?.didTappedActionType?(actionType)
+            if let actionType = self?.actionType, let alertType = self?.alertType {
+                self?.didConfirmActionType?(actionType, alertType)
                 self?.isHidden = true
             }
         }

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
@@ -194,6 +194,7 @@ final class EditHouseWorkViewController: BaseViewController {
         hidekeyboardWhenTappedAround()
         getTeamInfo()
         addButtonAction()
+        didConfirmRepeatAlertActionType()
     }
     
     override func render() {
@@ -644,6 +645,29 @@ final class EditHouseWorkViewController: BaseViewController {
         repeatCycleDayLabel.isHidden = true
         repeatCycleMenu.isHidden = true
     }
+    
+    private func didConfirmRepeatAlertActionType() {
+        repeatAlertView.didConfirmActionType = { [weak self] actionType, alertType in
+            switch alertType {
+            case .edit:
+                DispatchQueue.main.async {
+                    self?.editHouseWork?.type = actionType.rawValue
+                    self?.editHouseWork?.repeatEndDate = self?.editHouseWork?.scheduledDate
+                    self?.editHouseWork?.updateStandardDate = Date().dateToAPIString
+                    if let editHouseWork = self?.editHouseWork {
+                        self?.putEditHouseWork(body: editHouseWork)
+                    }
+                }
+            case .delete:
+                DispatchQueue.main.async {
+                    if let editHouseWork = self?.editHouseWork {
+                        self?.deleteHouseWork(body: DeleteHouseWorkRequest(deleteStandardDate: Date().dateToAPIString, houseWorkId:  editHouseWork.houseWorkId, type: actionType.rawValue))
+                    }
+                }
+            }
+            self?.popToHome()
+        }
+    }
 }
 
 // MARK: - extension
@@ -719,7 +743,6 @@ extension EditHouseWorkViewController {
         let action = UIAction { [weak self] _ in
             self?.repeatAlertView.alertType = .edit
             self?.repeatAlertView.isHidden = false
-            self?.popToHome()
         }
         doneButton.addAction(action, for: .touchUpInside)
     }

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
@@ -661,9 +661,9 @@ final class EditHouseWorkViewController: BaseViewController {
                 }
             case .delete:
                 DispatchQueue.main.async {
-                    print(alertType)
                     if let editHouseWork = self?.editHouseWork {
-                        self?.deleteHouseWork(body: DeleteHouseWorkRequest(deleteStandardDate: Date().dateToAPIString, houseWorkId:  editHouseWork.houseWorkId, type: actionType.rawValue))
+                        let requestBody = DeleteHouseWorkRequest(deleteStandardDate: Date().dateToAPIString, houseWorkId: editHouseWork.houseWorkId, type: actionType.rawValue)
+                        self?.deleteHouseWork(body: requestBody)
                     }
                 }
             }

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
@@ -14,7 +14,7 @@ final class EditHouseWorkViewController: BaseViewController {
     private let houseWorkMaxLength = 16
     private var selectedDay: Date = Date() {
         didSet {
-            if editHouseWork?.repeatCycle == "W" {
+            if editHouseWork?.repeatCycle == RepeatCycleType.week.rawValue {
                 updateRepeatCycleDayLabel(.week, selectedDay.dayOfWeekToKoreanString)
             } else {
                 updateRepeatCycleDayLabel(.month, selectedDay.singleDayToKoreanString)
@@ -176,7 +176,8 @@ final class EditHouseWorkViewController: BaseViewController {
     // MARK: - life cycle
     
     init(editHouseWork: EditHouseWorkRequest) {
-        self.editHouseWork = EditHouseWorkRequest(assignees: [11, 38], houseWorkId: 609, houseWorkName: "창 청소", repeatCycle: "W", repeatPattern: "MONDAY,SUNDAY", scheduledDate: "2023-05-02", scheduledTime: "16:02", space: "LIVINGROOM")
+        // FIXME: - Home 집안일과 연결
+        self.editHouseWork = EditHouseWorkRequest(assignees: [11], houseWorkId: 603, houseWorkName: "마중 나가기", repeatCycle: "O", repeatPattern: "2023-04-21", scheduledDate: "2023-04-21", space: "OUTSIDE")
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -371,10 +372,10 @@ final class EditHouseWorkViewController: BaseViewController {
             timePicker.date = time
         }
         
-        if editHouseWork?.repeatCycle != "O" {
+        if editHouseWork?.repeatCycle != RepeatCycleType.once.rawValue {
             setRepeatToggle.isOn = true
             showRepeatComponents()
-            if editHouseWork?.repeatCycle == "W" {
+            if editHouseWork?.repeatCycle == RepeatCycleType.week.rawValue {
                 if let dayOfWeek = editHouseWork?.repeatPattern?.components(separatedBy: ",") {
                     var koreanDayOfWeek: [String] = []
                     var collectionViewDayOfWeek: [String] = []
@@ -660,6 +661,7 @@ final class EditHouseWorkViewController: BaseViewController {
                 }
             case .delete:
                 DispatchQueue.main.async {
+                    print(alertType)
                     if let editHouseWork = self?.editHouseWork {
                         self?.deleteHouseWork(body: DeleteHouseWorkRequest(deleteStandardDate: Date().dateToAPIString, houseWorkId:  editHouseWork.houseWorkId, type: actionType.rawValue))
                     }


### PR DESCRIPTION
## 📣 Related Issue
- close #175 

## 👩‍💻 Contents & Screenshot
드디어 !! api 쪽은 다 마무리가 됐네요 !!
저의 게으름 때문에 일정이 많이 미뤄졌네요,,,

아래는 611번 집안일을 삭제 했을 때 출력된 결과를 캡처한 겁니다.
<img width="819" alt="스크린샷 2023-05-17 오후 7 45 16" src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/24490882-8e6b-4746-8922-4e460d7fb733">
수정도 마찬가지로 잘 동작하는 거 확인했어요!

이 피알에서 진행한 내용은 아래와 같습니다.
1) 일정 수정/삭제 전 뜨는 RepeatAlertView에 ScheduleActionType을 추가했습니다. (이 일정, 이 일정 및 향후 일정, 모든 일정)
유저가 타입을 선택하고 확인 버튼을 누르면 선택된 내용이 EditHouseWorkVC로 전달하도록 클로저를 생성했습니다.
2) RepeatAlertView에서 확인 버튼을 누르면 EditHouseWorkVC에서 해당 사항을 detect 하고 있다가 수정 또는 삭제 api 를 호출합니다. 이때 request body에 적절한 값이 들어갈 수 있도록 데이터를 먼저 처리합니다.


## 📌 Review Point
아직 Home과 EditHouseWorkVC의 data binding은 진행하지 않았습니다. 때문에 init 부분에 data를 임의로 넣어두었는데요.
먼저 swagger에서 개별 집안일 조회 api (houseWorkId로 검색하는 api)로 600번대 숫자 중 하나를 무작위로 검색해본 후 적절한 형태로 response가 오는 id를 골라서 init 부분에 넣고 테스트 하시는 걸 추천드립니다. DB 데이터에 의존적이라서 request를 보낼 때 형식이 조금이라도 벗어나면 바로 오류가 뜨더라구요..!
(지금 pr 에 넣어둔 목데이터는 수정/삭제 안한 데이터이니 그대로 시도하시면 돼요)

그리고 개발 서버 주소 바뀐 거 먼저 확인하시고 개발하시면,, 혼란을 피할 수 있습니다,,,! 😁


## 🔓 Next Step
- HomeVC -> EditHouseWorkVC data binding
- SelectHouseWorkVC -> SetHouseWorkVC data binding
- 이외 빠진 부분 연결