### PR TITLE
[ADD] Apple Login

### DIFF
--- a/fairer-iOS/fairer-iOS/Global/Util/RootHandler.swift
+++ b/fairer-iOS/fairer-iOS/Global/Util/RootHandler.swift
@@ -16,6 +16,6 @@ final class RootHandler {
         
         // MARK: - 로그인 뷰로 이동
         sceneDelegate.window?.rootViewController = loginViewController
-        LoginViewController.navigationController?.setViewControllers([loginViewController], animated: true)
+        loginViewController.navigationController?.setViewControllers([loginViewController], animated: true)
     }
 }

--- a/fairer-iOS/fairer-iOS/Network/API/HouseWorkCompleteRouterAPI.swift
+++ b/fairer-iOS/fairer-iOS/Network/API/HouseWorkCompleteRouterAPI.swift
@@ -58,7 +58,6 @@ final class HouseWorkCompleteRouterAPI {
         let decoder = JSONDecoder()
         switch statusCode {
         case 200..<300:
-        case 200..<300:
             if let authorization = response?.allHeaderFields["Authorization"] as? String,
                let token = authorization.split(separator: " ").last {
                 UserDefaultHandler.accessToken = String(token)

--- a/fairer-iOS/fairer-iOS/Network/API/MembersAPI.swift
+++ b/fairer-iOS/fairer-iOS/Network/API/MembersAPI.swift
@@ -31,9 +31,6 @@ final class MembersAPI {
             }
         }
     }
-    
-
-    private func judgeStatus(by statusCode: Int, _ data: Data, response: HTTPURLResponse?,  responseData: ResponseData) -> NetworkResult<Any> {
 
     func petchMemberInfo(body: MemberPatchRequest, completion: @escaping (NetworkResult<Any>) -> Void) {
         membersProvider.request(.petchMemberInfo(body: body)) { result in
@@ -41,7 +38,8 @@ final class MembersAPI {
             case .success(let response):
                 let statusCode = response.statusCode
                 let data = response.data
-                let networkResult = self.judgeStatus(by: statusCode, data, responseData: .getMemberInfo)
+                let httpUrlResponse = response.response
+                let networkResult = self.judgeStatus(by: statusCode, data, response: httpUrlResponse, responseData: .petchMemberInfo)
                 completion(networkResult)
             case .failure(let err):
                 print(err)
@@ -49,49 +47,48 @@ final class MembersAPI {
         }
     }
         
-    
-    private func judgeStatus(by statusCode: Int, _ data: Data, responseData: ResponseData) -> NetworkResult<Any> {
-        let decoder = JSONDecoder()
-        switch statusCode {
-        case 200..<300:
-            if let authorization = response?.allHeaderFields["Authorization"] as? String,
-               let token = authorization.split(separator: " ").last {
-                UserDefaultHandler.accessToken = String(token)
+        private func judgeStatus(by statusCode: Int, _ data: Data, response: HTTPURLResponse?, responseData: ResponseData) -> NetworkResult<Any> {
+            let decoder = JSONDecoder()
+            switch statusCode {
+            case 200..<300:
+                if let authorization = response?.allHeaderFields["Authorization"] as? String,
+                   let token = authorization.split(separator: " ").last {
+                    UserDefaultHandler.accessToken = String(token)
+                }
+                switch responseData {
+                case .getMemberInfo, .petchMemberInfo:
+                    return isValidData(data: data, responseData: responseData)
+                }
+            case 400:
+                guard let decodedData = try? decoder.decode(UserErrorResponse.self, from: data) else {
+                    return .pathErr
+                }
+                return .requestErr(decodedData)
+            case 401..<500:
+                guard let decodedData = try? decoder.decode(ErrorResponse.self, from: data) else {
+                    return .pathErr
+                }
+                return .requestErr(decodedData)
+            case 500:
+                return .serverErr
+            default:
+                return .networkFail
             }
+        }
+        
+        private func isValidData(data: Data, responseData: ResponseData) -> NetworkResult<Any> {
+            let decoder = JSONDecoder()
             switch responseData {
-            case .getMemberInfo, .petchMemberInfo:
-                return isValidData(data: data, responseData: responseData)
+            case .getMemberInfo:
+                guard let decodedData = try? decoder.decode(MemberResponse.self, from: data) else {
+                    return .pathErr
+                }
+                return .success(decodedData)
+            case .petchMemberInfo:
+                guard let decodedData = try? decoder.decode(MemberPatchResponse.self, from: data) else {
+                    return .pathErr
+                }
+                return .success(decodedData)
             }
-        case 400:
-            guard let decodedData = try? decoder.decode(UserErrorResponse.self, from: data) else {
-                return .pathErr
-            }
-            return .requestErr(decodedData)
-        case 401..<500:
-            guard let decodedData = try? decoder.decode(ErrorResponse.self, from: data) else {
-                return .pathErr
-            }
-            return .requestErr(decodedData)
-        case 500:
-            return .serverErr
-        default:
-            return .networkFail
         }
     }
-    
-    private func isValidData(data: Data, responseData: ResponseData) -> NetworkResult<Any> {
-        let decoder = JSONDecoder()
-        switch responseData {
-        case .getMemberInfo:
-            guard let decodedData = try? decoder.decode(MemberResponse.self, from: data) else {
-                return .pathErr
-            }
-            return .success(decodedData)
-        case .petchMemberInfo:
-            guard let decodedData = try? decoder.decode(MemberPatchResponse.self, from: data) else {
-                return .pathErr
-            }
-            return .success(decodedData)
-        }
-    }
-}

--- a/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
@@ -16,7 +16,6 @@ final class LoginViewController: BaseViewController {
     // MARK: - property
 
     private let signInConfig = GIDConfiguration.init(clientID: "", serverClientID: "")
-    private let OauthRequestData = AuthRequest()
     private let logoImage = UIImageView(image: ImageLiterals.imgLogoLogin)
     private let loginLabel: UILabel = {
         let label = UILabel()
@@ -208,10 +207,8 @@ extension LoginViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
                    let authString = String(data: authorizationCode, encoding: .utf8),
                    let tokenString = String(data: identityToken, encoding: .utf8) {
 
-                    print("authorizationCode: \(authorizationCode)")
-                    print("identityToken: \(identityToken)")
-                    print("authString: \(authString)")
-                    print("tokenString: \(tokenString)")
+                    print("authorizationCode String: \(authString)")
+                    print("identityToken String: \(tokenString)")
                 }
                 
                 print("User ID : \(userIdentifier)")

--- a/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
@@ -213,16 +213,20 @@ extension LoginViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
                     print("authString: \(authString)")
                     print("tokenString: \(tokenString)")
                 }
-
+                
                 print("User ID : \(userIdentifier)")
                 print("User Email : \(email ?? "")")
                 print("User Name : \(name)")
-
+                
             default:
                 break
             }
-        }
-
+    }
+    
+    // Apple ID 연동 실패 시
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        print("Apple Error")
+    }
 }
 
 

--- a/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
@@ -155,14 +155,24 @@ final class LoginViewController: BaseViewController {
 extension LoginViewController {
     
     private func setButtonAction() {
-        let moveToOnboardingView = UIAction { [weak self] _ in
-            self?.googlelogin()
+        let moveToGoogleLogin = UIAction { [weak self] _ in
+            self?.googleLogin()
         }
         
-        self.googleButton.addAction(moveToOnboardingView, for: .touchUpInside)
+        let moveToAppleLogin = UIAction { [weak self] _ in
+            self?.appleSignIn()
+        }
+        
+        self.googleButton.addAction(moveToGoogleLogin, for: .touchUpInside)
+        self.appleButton.addAction(moveToAppleLogin, for: .touchUpInside)
     }
 
-    private func googlelogin() {
+    private func googleLogin() {
         googleSignIn()
     }
+    
+    private func appleLogin() {
+        appleSignIn()
+    }
 }
+

--- a/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import SnapKit
 import GoogleSignIn
+import AuthenticationServices
 
 final class LoginViewController: BaseViewController {
 
@@ -128,6 +129,17 @@ final class LoginViewController: BaseViewController {
                 self.navigationController?.pushViewController(onBoardingNameViewController, animated: true)
             }
         }
+    }
+    
+    private func appleSignIn() {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+        
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.presentationContextProvider = self
+        authorizationController.performRequests()
     }
     
     func postSignIn(socialType: String) {

--- a/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
@@ -192,6 +192,37 @@ extension LoginViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         return view.window!
     }
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+            switch authorization.credential {
+               case let appleIDCredential as ASAuthorizationAppleIDCredential:
+
+                // Create an account in your system.
+                let userIdentifier = appleIDCredential.user
+                let fullName = appleIDCredential.fullName
+                let name =  (fullName?.familyName ?? "") + (fullName?.givenName ?? "")
+                let email = appleIDCredential.email
+
+                if let authorizationCode = appleIDCredential.authorizationCode,
+                   let identityToken = appleIDCredential.identityToken,
+                   let authString = String(data: authorizationCode, encoding: .utf8),
+                   let tokenString = String(data: identityToken, encoding: .utf8) {
+
+                    print("authorizationCode: \(authorizationCode)")
+                    print("identityToken: \(identityToken)")
+                    print("authString: \(authString)")
+                    print("tokenString: \(tokenString)")
+                }
+
+                print("User ID : \(userIdentifier)")
+                print("User Email : \(email ?? "")")
+                print("User Name : \(name)")
+
+            default:
+                break
+            }
+        }
+
 }
 
 

--- a/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
@@ -188,3 +188,10 @@ extension LoginViewController {
     }
 }
 
+extension LoginViewController: ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return view.window!
+    }
+}
+
+


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #178 

## 👩‍💻 Contents & Screenshot
<!-- 작업 내용과 이미지를 첨부해주세요. -->
<img width="770" alt="스크린샷 2023-05-18 오후 12 34 28" src="https://github.com/fairer-iOS/fairer-iOS/assets/25146374/19666362-b9be-4ca5-a511-00fa0423e411">


## 📌 Review Point
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- 프로비저닝 인증서 설정한 상태에서 다시 애플로그인 구현했습니다.
- credential에서 내려오는 identityToken를 통해 토큰 서드파티로 백엔드와 유효성검사를 진행하면 될 거 같습니다.
- 더불어 최초 로그인에만 이름과 이메일을 받을 수 있고, 두번째 로그인부터는 앱에서 Apple ID 사용 중단하기 전까지 ID 값만 리턴한다고 합니다.

## 🧐 Question
<!-- PR 과정에서 생긴 질문을 적어주세요. -->
- 가입한 상태에서 앱을 삭제하고 다시 설치 시 로그인 할 때 온보딩이 아닌 메인으로 가게 하려면 어떻게 구현해야하나 고민이 드네요!
- 이전 토큰 풀리퀘에서 발견된 오류가 있어서 이 브랜치 얼른 머지해야 오류 안날 거 같아요!
