### PR TITLE
[ADD] 집안일 생성/수정 화면 - 데이터 바인딩

### DIFF
--- a/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
+++ b/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
@@ -193,6 +193,7 @@ enum TextLiteral {
     static let writeHouseWorkViewControllerHouseWorkNameTextFieldPlaceholderText = "직접 입력"
     static let writeHouseWorkViewControllerHouseWorkNameWarningLabel = "텍스트는 16글자를 초과하여 입력하실 수 없어요."
     static let writeHouseWorkViewControllerDeleteLabel = "삭제"
+    static let writeHouseWorkViewControllerSpaceLabel = "기타 공간"
     
     // MARK: - EditHouseWorkViewController
     

--- a/fairer-iOS/fairer-iOS/Global/UIComponent/CalendarSpaceView.swift
+++ b/fairer-iOS/fairer-iOS/Global/UIComponent/CalendarSpaceView.swift
@@ -14,9 +14,8 @@ final class CalendarSpaceView: BaseUIView {
     // MARK: - property
     
     let pickDateButton = PickDateButton()
-    let spaceLabel: UILabel = {
+    var spaceLabel: UILabel = {
         let label = UILabel()
-        label.text = Space.livingRoom.rawValue
         label.textColor = .black
         label.font = .title1
         return label

--- a/fairer-iOS/fairer-iOS/Network/API/HouseWorksAPI.swift
+++ b/fairer-iOS/fairer-iOS/Network/API/HouseWorksAPI.swift
@@ -173,7 +173,7 @@ final class HouseWorksAPI {
         case .deleteHouseWork:
             return .success(BlankResponse())
         case .getHouseWorkById:
-            guard let decodedData = try? decoder.decode(HouseWorkIdResponse.self, from: data) else {
+            guard let decodedData = try? decoder.decode(HouseWorkResponse.self, from: data) else {
                 return .pathErr
             }
             return .success(decodedData)

--- a/fairer-iOS/fairer-iOS/Network/API/HouseWorksAPI.swift
+++ b/fairer-iOS/fairer-iOS/Network/API/HouseWorksAPI.swift
@@ -19,6 +19,7 @@ final class HouseWorksAPI {
         case getMemberHouseWorksByDate
         case putEditHouseWork
         case deleteHouseWork
+        case getHouseWorkById
     }
     
     public func getHouseWorksByDate(
@@ -105,6 +106,20 @@ final class HouseWorksAPI {
         }
     }
     
+    func getHouseWorkById(houseWorkId: Int, completion: (NetworkResult<Any>) -> Void) {
+        provider.request(.getHouseWorkById(houseWorkId: houseWorkId)) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let httpUrlResponse = response.response
+                let networkResult = self.judgeStatus(by: statusCode, data, response: httpUrlResponse, responseData: .getHouseWorkById)
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+    
     private func judgeStatus(by statusCode: Int, _ data: Data, response: HTTPURLResponse?, responseData: ResponseData) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
         
@@ -115,11 +130,7 @@ final class HouseWorksAPI {
                 UserDefaultHandler.accessToken = String(token)
             }
             switch responseData {
-            case .getHouseWorksByDate, .postAddHouseWorks, .getMemberHouseWorksByDate:
-                return isValidData(data: data, responseData: responseData)
-            case .putEditHouseWork:
-                return isValidData(data: data, responseData: responseData)
-            case .deleteHouseWork:
+            case .getHouseWorksByDate, .postAddHouseWorks, .getMemberHouseWorksByDate, .getHouseWorkById, .putEditHouseWork, .deleteHouseWork:
                 return isValidData(data: data, responseData: responseData)
             }
         case 400..<500:
@@ -160,6 +171,11 @@ final class HouseWorksAPI {
             return .success(decodedData)
         case .deleteHouseWork:
             return .success(BlankResponse())
+        case .getHouseWorkById:
+            guard let decodedData = try? decoder.decode(HouseWorkResponse.self, from: data) else {
+                return .pathErr
+            }
+            return .success(decodedData)
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Network/API/HouseWorksAPI.swift
+++ b/fairer-iOS/fairer-iOS/Network/API/HouseWorksAPI.swift
@@ -106,7 +106,7 @@ final class HouseWorksAPI {
         }
     }
     
-    func getHouseWorkById(houseWorkId: Int, completion: (NetworkResult<Any>) -> Void) {
+    func getHouseWorkById(houseWorkId: Int, completion: @escaping (NetworkResult<Any>) -> Void) {
         provider.request(.getHouseWorkById(houseWorkId: houseWorkId)) { result in
             switch result {
             case .success(let response):
@@ -114,6 +114,7 @@ final class HouseWorksAPI {
                 let data = response.data
                 let httpUrlResponse = response.response
                 let networkResult = self.judgeStatus(by: statusCode, data, response: httpUrlResponse, responseData: .getHouseWorkById)
+                completion(networkResult)
             case .failure(let err):
                 print(err)
             }
@@ -172,7 +173,7 @@ final class HouseWorksAPI {
         case .deleteHouseWork:
             return .success(BlankResponse())
         case .getHouseWorkById:
-            guard let decodedData = try? decoder.decode(HouseWorkResponse.self, from: data) else {
+            guard let decodedData = try? decoder.decode(HouseWorkIdResponse.self, from: data) else {
                 return .pathErr
             }
             return .success(decodedData)

--- a/fairer-iOS/fairer-iOS/Network/DTO/HouseWorks/HouseWorksResponse.swift
+++ b/fairer-iOS/fairer-iOS/Network/DTO/HouseWorks/HouseWorksResponse.swift
@@ -11,27 +11,15 @@ typealias HouseWorksResponse = [HouseWorkResponse]
 
 struct HouseWorkResponse: Codable {
     let assignees: [MemberResponse]
-    let houseWorkCompleteId: Int
+    let houseWorkCompleteId: Int?
     let houseWorkId: Int
     let houseWorkName: String
     let repeatCycle: String
-    let repeatEndDate: String
+    let repeatEndDate: String?
     let repeatPattern: String
-    let scheduledDate: String
-    let scheduledTime: String
-    let space: String
-    let success: Bool
-    let successDateTime: String
-}
-
-struct HouseWorkIdResponse: Codable {
-    let houseWorkId: Int
-    let space: String
-    let houseWorkName: String
-    let assignees: [MemberResponse]
     let scheduledDate: String
     let scheduledTime: String?
+    let space: String
     let success: Bool
-    let repeatCycle: String
-    let repeatPattern: String
+    let successDateTime: String?
 }

--- a/fairer-iOS/fairer-iOS/Network/DTO/HouseWorks/HouseWorksResponse.swift
+++ b/fairer-iOS/fairer-iOS/Network/DTO/HouseWorks/HouseWorksResponse.swift
@@ -30,6 +30,7 @@ struct HouseWorkIdResponse: Codable {
     let houseWorkName: String
     let assignees: [MemberResponse]
     let scheduledDate: String
+    let scheduledTime: String?
     let success: Bool
     let repeatCycle: String
     let repeatPattern: String

--- a/fairer-iOS/fairer-iOS/Network/DTO/HouseWorks/HouseWorksResponse.swift
+++ b/fairer-iOS/fairer-iOS/Network/DTO/HouseWorks/HouseWorksResponse.swift
@@ -23,3 +23,14 @@ struct HouseWorkResponse: Codable {
     let success: Bool
     let successDateTime: String
 }
+
+struct HouseWorkIdResponse: Codable {
+    let houseWorkId: Int
+    let space: String
+    let houseWorkName: String
+    let assignees: [MemberResponse]
+    let scheduledDate: String
+    let success: Bool
+    let repeatCycle: String
+    let repeatPattern: String
+}

--- a/fairer-iOS/fairer-iOS/Network/Router/HouseWorksRouter.swift
+++ b/fairer-iOS/fairer-iOS/Network/Router/HouseWorksRouter.swift
@@ -63,8 +63,8 @@ extension HouseWorksRouter: BaseTargetType {
             return .requestJSONEncodable(body)
         case .deleteHouseWork(let body):
             return .requestJSONEncodable(body)
-        case .getHouseWorkById(_):
-            return .requestPlain
+        case .getHouseWorkById(let houseWorkId):
+            return .requestParameters(parameters: ["houseWorkId": houseWorkId], encoding: URLEncoding.default)
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Network/Router/HouseWorksRouter.swift
+++ b/fairer-iOS/fairer-iOS/Network/Router/HouseWorksRouter.swift
@@ -15,6 +15,7 @@ enum HouseWorksRouter {
     case getMemberHouseWorksByDate(fromDate: String, toDate: String, teamMemberId: Int)
     case putEditHouseWork(body: EditHouseWorkRequest)
     case deleteHouseWork(body: DeleteHouseWorkRequest)
+    case getHouseWorkById(houseWorkId: Int)
 }
 
 extension HouseWorksRouter: BaseTargetType {
@@ -30,6 +31,8 @@ extension HouseWorksRouter: BaseTargetType {
             return URLConstant.houseWorks + "/v2"
         case .deleteHouseWork(_):
             return URLConstant.houseWorks + "/v2"
+        case .getHouseWorkById(let houseWorkId):
+            return URLConstant.houseWorks + "/\(houseWorkId)/detail"
         }
     }
     
@@ -43,6 +46,8 @@ extension HouseWorksRouter: BaseTargetType {
             return .put
         case .deleteHouseWork(_):
             return .delete
+        case .getHouseWorkById(_):
+            return .get
         }
     }
     
@@ -58,6 +63,8 @@ extension HouseWorksRouter: BaseTargetType {
             return .requestJSONEncodable(body)
         case .deleteHouseWork(let body):
             return .requestJSONEncodable(body)
+        case .getHouseWorkById(_):
+            return .requestPlain
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -259,7 +259,8 @@ extension HomeViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let selectedHouseWorkId = pickDayWorkInfo?.houseWorks?[indexPath.section].houseWorkId else { return }
-        let editHouseWorkView = EditHouseWorkViewController(houseWorkId: selectedHouseWorkId)
+        guard let selectedHouseWorkDate = pickDayWorkInfo?.houseWorks?[indexPath.section].scheduledDate else { return }
+        let editHouseWorkView = EditHouseWorkViewController(houseWorkId: selectedHouseWorkId, houseWorkDate: selectedHouseWorkDate)
         self.navigationController?.pushViewController(editHouseWorkView, animated: true)
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -258,14 +258,8 @@ extension HomeViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let selectedHouseWork = pickDayWorkInfo?.houseWorks?[indexPath.section] else { return }
-        var selectedHouseWorkAssigness: [Int] = []
-        selectedHouseWork.assignees?.forEach {
-            if let memberId = $0.memberId {
-                selectedHouseWorkAssigness.append(memberId)
-            }
-        }
-        let editHouseWorkView = EditHouseWorkViewController(editHouseWork: EditHouseWorkRequest(assignees: selectedHouseWorkAssigness, houseWorkId: selectedHouseWork.houseWorkId, houseWorkName: selectedHouseWork.houseWorkName, scheduledDate: selectedHouseWork.scheduledDate, scheduledTime: selectedHouseWork.scheduledTime))
+        guard let selectedHouseWorkId = pickDayWorkInfo?.houseWorks?[indexPath.section].houseWorkId else { return }
+        let editHouseWorkView = EditHouseWorkViewController(houseWorkId: selectedHouseWorkId)
         self.navigationController?.pushViewController(editHouseWorkView, animated: true)
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -258,8 +258,14 @@ extension HomeViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // MARK: - fix me, houseWorks 빈 배열 대체
-        let editHouseWorkView = EditHouseWorkViewController(editHouseWork: EditHouseWorkRequest())
+        guard let selectedHouseWork = pickDayWorkInfo?.houseWorks?[indexPath.section] else { return }
+        var selectedHouseWorkAssigness: [Int] = []
+        selectedHouseWork.assignees?.forEach {
+            if let memberId = $0.memberId {
+                selectedHouseWorkAssigness.append(memberId)
+            }
+        }
+        let editHouseWorkView = EditHouseWorkViewController(editHouseWork: EditHouseWorkRequest(assignees: selectedHouseWorkAssigness, houseWorkId: selectedHouseWork.houseWorkId, houseWorkName: selectedHouseWork.houseWorkName, scheduledDate: selectedHouseWork.scheduledDate, scheduledTime: selectedHouseWork.scheduledTime))
         self.navigationController?.pushViewController(editHouseWorkView, animated: true)
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
@@ -361,6 +361,8 @@ final class EditHouseWorkViewController: BaseViewController {
     }
     
     private func setLatestContents() {
+        writeHouseWorkCalendarView.spaceLabel.text = Space.allCases.first { $0.spaceUpper == editHouseWork.space}?.rawValue
+        
         houseWorkNameTextField.text = editHouseWork.houseWorkName
         
         if let time = editHouseWork.scheduledTime?.stringToTime {

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
@@ -29,6 +29,7 @@ final class EditHouseWorkViewController: BaseViewController {
         }
     }
     private var houseWorkId: Int = 0
+    private var houseWork: HouseWorkResponse?
     
     // MARK: - property
     
@@ -185,6 +186,7 @@ final class EditHouseWorkViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        getHouseWorkById()
         setLatestContents()
         setDeleteButton()
         setDatePicker()
@@ -731,6 +733,20 @@ extension EditHouseWorkViewController {
             case .success(let response):
                 dump(response)
                 break
+            case .requestErr(let errorResponse):
+                dump(errorResponse)
+            default:
+                break
+            }
+        }
+    }
+    
+    private func getHouseWorkById() {
+        NetworkService.shared.houseWorks.getHouseWorkById(houseWorkId: houseWorkId) { result in
+            switch result {
+            case .success(let response):
+                self.houseWork = response as? HouseWorkResponse
+                dump(response)
             case .requestErr(let errorResponse):
                 dump(errorResponse)
             default:

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
@@ -364,7 +364,7 @@ final class EditHouseWorkViewController: BaseViewController {
     private func setLatestContents() {
         houseWorkNameTextField.text = houseWork?.houseWorkName
         
-        if let time = editHouseWork?.scheduledTime?.stringToTime {
+        if let time = houseWork?.scheduledTime?.stringToTime {
             setTimeToggle.isOn = true
             timePicker.snp.updateConstraints {
                 $0.top.equalTo(setTimeLabel.snp.bottom).offset(8)
@@ -373,11 +373,11 @@ final class EditHouseWorkViewController: BaseViewController {
             timePicker.date = time
         }
         
-        if editHouseWork?.repeatCycle != RepeatCycleType.once.rawValue {
+        if houseWork?.repeatCycle != RepeatCycleType.once.rawValue {
             setRepeatToggle.isOn = true
             showRepeatComponents()
-            if editHouseWork?.repeatCycle == RepeatCycleType.week.rawValue {
-                if let dayOfWeek = editHouseWork?.repeatPattern?.components(separatedBy: ",") {
+            if houseWork?.repeatCycle == RepeatCycleType.week.rawValue {
+                if let dayOfWeek = houseWork?.repeatPattern.components(separatedBy: ",") {
                     var koreanDayOfWeek: [String] = []
                     var collectionViewDayOfWeek: [String] = []
                     for day in dayOfWeek {
@@ -399,6 +399,8 @@ final class EditHouseWorkViewController: BaseViewController {
             setRepeatToggle.isOn = false
             hideRepeatComponents()
         }
+        
+        
     }
     
     private func setupDelegation() {
@@ -693,14 +695,15 @@ extension EditHouseWorkViewController {
             case .success(let response):
                 guard let teamInfo = response as? TeamInfoResponse else { return }
                 guard let membersInfo = teamInfo.members else { return }
+                let selectedMemberList = self.houseWork?.assignees.map { $0.memberId }
                 DispatchQueue.main.async {
-                    let selectedMemberList = membersInfo.filter { member in
-                        self.editHouseWork?.assignees?.contains { assignee in
+                    let selectedMemberInfo = membersInfo.filter { member in
+                        selectedMemberList?.contains { assignee in
                             member.memberId == assignee
                         } ?? false
                     }
-                    self.getManagerView.getManagerCollectionView.selectedMemberList = selectedMemberList
-                    self.selectManagerView.selectManagerCollectionView.selectedManagerList = selectedMemberList
+                    self.getManagerView.getManagerCollectionView.selectedMemberList = selectedMemberInfo
+                    self.selectManagerView.selectManagerCollectionView.selectedManagerList = selectedMemberInfo
                     self.selectManagerView.selectManagerCollectionView.totalMemberList = membersInfo
                 }
                 break

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
@@ -29,6 +29,7 @@ final class EditHouseWorkViewController: BaseViewController {
         }
     }
     private var houseWorkId: Int = 0
+    private var houseWorkDate: String = ""
     
     // MARK: - property
     
@@ -176,8 +177,9 @@ final class EditHouseWorkViewController: BaseViewController {
     
     // MARK: - life cycle
     
-    init(houseWorkId: Int) {
+    init(houseWorkId: Int, houseWorkDate: String) {
         self.houseWorkId = houseWorkId
+        self.houseWorkDate = houseWorkDate
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -656,7 +658,7 @@ final class EditHouseWorkViewController: BaseViewController {
                 DispatchQueue.main.async {
                     self?.editHouseWork.type = actionType.rawValue
                     self?.editHouseWork.repeatEndDate = self?.editHouseWork.scheduledDate
-                    self?.editHouseWork.updateStandardDate = Date().dateToAPIString
+                    self?.editHouseWork.updateStandardDate = self?.houseWorkDate
                     if let editHouseWork = self?.editHouseWork {
                         self?.putEditHouseWork(body: editHouseWork)
                     }
@@ -664,7 +666,7 @@ final class EditHouseWorkViewController: BaseViewController {
             case .delete:
                 DispatchQueue.main.async {
                     if let editHouseWork = self?.editHouseWork {
-                        let requestBody = DeleteHouseWorkRequest(deleteStandardDate: Date().dateToAPIString, houseWorkId: editHouseWork.houseWorkId, type: actionType.rawValue)
+                        let requestBody = DeleteHouseWorkRequest(deleteStandardDate: self?.houseWorkDate, houseWorkId: editHouseWork.houseWorkId, type: actionType.rawValue)
                         self?.deleteHouseWork(body: requestBody)
                     }
                 }

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
@@ -28,6 +28,7 @@ final class EditHouseWorkViewController: BaseViewController {
             }
         }
     }
+    private var houseWorkId: Int = 0
     
     // MARK: - property
     
@@ -175,10 +176,8 @@ final class EditHouseWorkViewController: BaseViewController {
     
     // MARK: - life cycle
     
-    init(editHouseWork: EditHouseWorkRequest) {
-        // FIXME: - Home 집안일과 연결
-        self.editHouseWork = editHouseWork
-        print("수정화면에서 확인", self.editHouseWork)
+    init(houseWorkId: Int) {
+        self.houseWorkId = houseWorkId
         super.init(nibName: nil, bundle: nil)
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
@@ -177,7 +177,8 @@ final class EditHouseWorkViewController: BaseViewController {
     
     init(editHouseWork: EditHouseWorkRequest) {
         // FIXME: - Home 집안일과 연결
-        self.editHouseWork = EditHouseWorkRequest(assignees: [11], houseWorkId: 603, houseWorkName: "마중 나가기", repeatCycle: "O", repeatPattern: "2023-04-21", scheduledDate: "2023-04-21", space: "OUTSIDE")
+        self.editHouseWork = editHouseWork
+        print("수정화면에서 확인", self.editHouseWork)
         super.init(nibName: nil, bundle: nil)
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
@@ -29,7 +29,6 @@ final class EditHouseWorkViewController: BaseViewController {
         }
     }
     private var houseWorkId: Int = 0
-    private var houseWork: HouseWorkResponse?
     
     // MARK: - property
     
@@ -361,13 +360,6 @@ final class EditHouseWorkViewController: BaseViewController {
         writeHouseWorkCalendarView.pickDateButton.addAction(action, for: .touchUpInside)
     }
     
-    private func setEditHouseWork(houseWork: HouseWorkResponse) {
-        editHouseWork = EditHouseWorkRequest(assignees: houseWork.assignees.map { $0.memberId ?? .zero }, houseWorkId: houseWork.houseWorkId, houseWorkName: houseWork.houseWorkName, repeatCycle: houseWork.repeatCycle, repeatEndDate: houseWork.repeatEndDate, repeatPattern: houseWork.repeatPattern, scheduledDate: houseWork.scheduledDate, scheduledTime: houseWork.scheduledTime, space: houseWork.space)
-        DispatchQueue.main.async {
-            self.setLatestContents()
-        }
-    }
-    
     private func setLatestContents() {
         houseWorkNameTextField.text = editHouseWork.houseWorkName
         
@@ -406,8 +398,6 @@ final class EditHouseWorkViewController: BaseViewController {
             setRepeatToggle.isOn = false
             hideRepeatComponents()
         }
-        
-        
     }
     
     private func setupDelegation() {
@@ -703,13 +693,13 @@ extension EditHouseWorkViewController {
                 guard let teamInfo = response as? TeamInfoResponse else { return }
                 guard let membersInfo = teamInfo.members else { return }
                 DispatchQueue.main.async {
-                    let selectedMemberInfo = membersInfo.filter { member in
+                    let selectedMemberList = membersInfo.filter { member in
                         self.editHouseWork.assignees?.contains { assignee in
                             member.memberId == assignee
                         } ?? false
                     }
-                    self.getManagerView.getManagerCollectionView.selectedMemberList = selectedMemberInfo
-                    self.selectManagerView.selectManagerCollectionView.selectedManagerList = selectedMemberInfo
+                    self.getManagerView.getManagerCollectionView.selectedMemberList = selectedMemberList
+                    self.selectManagerView.selectManagerCollectionView.selectedManagerList = selectedMemberList
                     self.selectManagerView.selectManagerCollectionView.totalMemberList = membersInfo
                 }
                 break
@@ -754,7 +744,10 @@ extension EditHouseWorkViewController {
             switch result {
             case .success(let response):
                 if let houseWork = response as? HouseWorkResponse {
-                    self.setEditHouseWork(houseWork: houseWork)
+                    self.editHouseWork = EditHouseWorkRequest(assignees: houseWork.assignees.map { $0.memberId ?? .zero }, houseWorkId: houseWork.houseWorkId, houseWorkName: houseWork.houseWorkName, repeatCycle: houseWork.repeatCycle, repeatEndDate: houseWork.repeatEndDate, repeatPattern: houseWork.repeatPattern, scheduledDate: houseWork.scheduledDate, scheduledTime: houseWork.scheduledTime, space: houseWork.space)
+                    DispatchQueue.main.async {
+                        self.setLatestContents()
+                    }
                 }
                 dump(response)
             case .requestErr(let errorResponse):

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
@@ -29,7 +29,7 @@ final class EditHouseWorkViewController: BaseViewController {
         }
     }
     private var houseWorkId: Int = 0
-    private var houseWork: HouseWorkResponse?
+    private var houseWork: HouseWorkIdResponse?
     
     // MARK: - property
     
@@ -187,7 +187,6 @@ final class EditHouseWorkViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         getHouseWorkById()
-        setLatestContents()
         setDeleteButton()
         setDatePicker()
         setupNotificationCenter()
@@ -363,7 +362,7 @@ final class EditHouseWorkViewController: BaseViewController {
     }
     
     private func setLatestContents() {
-        houseWorkNameTextField.text = editHouseWork?.houseWorkName
+        houseWorkNameTextField.text = houseWork?.houseWorkName
         
         if let time = editHouseWork?.scheduledTime?.stringToTime {
             setTimeToggle.isOn = true
@@ -745,8 +744,12 @@ extension EditHouseWorkViewController {
         NetworkService.shared.houseWorks.getHouseWorkById(houseWorkId: houseWorkId) { result in
             switch result {
             case .success(let response):
-                self.houseWork = response as? HouseWorkResponse
+                guard let houseWork = response as? HouseWorkIdResponse else { return }
+                self.houseWork = houseWork
                 dump(response)
+                DispatchQueue.main.async {
+                    self.setLatestContents()
+                }
             case .requestErr(let errorResponse):
                 dump(errorResponse)
             default:

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/SelectHouseWork/Model/Space.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/SelectHouseWork/Model/Space.swift
@@ -82,5 +82,22 @@ enum Space: String, CaseIterable {
             return SizeLiteral.houseWorkDetailThreeLineHeight
         }
     }
+    
+    var spaceUpper: String {
+        switch self {
+        case .entrance:
+            return "ENTRANCE"
+        case .livingRoom:
+            return "LIVINGROOM"
+        case .bathroom:
+            return "BATHROOM"
+        case .outside:
+            return "OUTSIDE"
+        case .room:
+            return "ROOM"
+        case .kitchen:
+            return "KITCHEN"
+        }
+    }
 }
 

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/SelectHouseWork/ViewController/SelectHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/SelectHouseWork/ViewController/SelectHouseWorkViewController.swift
@@ -188,8 +188,7 @@ final class SelectHouseWorkViewController: BaseViewController {
     }
     
     private func didTappedWriteHouseWorkButton() {
-        // MARK: - fix me : WriteHouseWorkViewController init 처리 필요
-        let writeHouseWorkView = WriteHouseWorkViewController(houseWorks: [HouseWorksRequest]())
+        let writeHouseWorkView = WriteHouseWorkViewController()
         self.navigationController?.pushViewController(writeHouseWorkView, animated: true)
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/SelectHouseWork/ViewController/SelectHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/SelectHouseWork/ViewController/SelectHouseWorkViewController.swift
@@ -12,6 +12,8 @@ import SnapKit
 final class SelectHouseWorkViewController: BaseViewController {
     
     var selectedSpace: Space?
+    var houseWorks: [String] = []
+    var houseWorksRequest: [HouseWorksRequest] = []
     
     // MARK: - property
     
@@ -186,16 +188,16 @@ final class SelectHouseWorkViewController: BaseViewController {
     }
     
     private func didTappedWriteHouseWorkButton() {
-        
         // MARK: - fix me : WriteHouseWorkViewController init 처리 필요
         let writeHouseWorkView = WriteHouseWorkViewController(houseWorks: [HouseWorksRequest]())
         self.navigationController?.pushViewController(writeHouseWorkView, animated: true)
     }
     
     private func didTappedNextButton() {
-        
-        // MARK: - fix me : SetHouseWorkViewController init 처리 필요
-        let setHouseWorkView = SetHouseWorkViewController(houseWorks: [])
+        self.houseWorksRequest = houseWorks.map { houseWorkName in
+            HouseWorksRequest(assignees: [], houseWorkName: houseWorkName, space: selectedSpace?.spaceUpper ?? "")
+        }
+        let setHouseWorkView = SetHouseWorkViewController(houseWorks: houseWorksRequest)
         self.navigationController?.pushViewController(setHouseWorkView, animated: true)
     }
     
@@ -214,6 +216,7 @@ final class SelectHouseWorkViewController: BaseViewController {
             } else {
                 self?.nextButton.isDisabled = true
             }
+            self?.houseWorks = houseWork
         }
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/SetHouseWork/ViewController/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/SetHouseWork/ViewController/SetHouseWorkViewController.swift
@@ -291,6 +291,7 @@ final class SetHouseWorkViewController: BaseViewController {
     
     private func setInitialHouseWork() {
         setHouseWorkCollectionView.totalHouseWorks = houseWorks
+        setHouseWorkCalendarView.spaceLabel.text = Space.allCases.first { $0.spaceUpper == houseWorks[0].space}?.rawValue
     }
     
     private func setDatePicker() {
@@ -324,7 +325,7 @@ final class SetHouseWorkViewController: BaseViewController {
             self.setHouseWorkCollectionView.totalHouseWorks = self.houseWorks
             
             if self.houseWorks.count == 0 {
-                // FIXME: - 이전 페이지로 이동
+                self.navigationController?.popToViewController(ofClass: SelectHouseWorkViewController.self)
             } else if deletedHouseWorkIndex == self.houseWorks.endIndex && deletedHouseWorkIndex == self.selectedHouseWorkIndex {
                 self.selectedHouseWorkIndex -= 1
                 self.repeatCycleCollectionView.selectedHouseWorkIndex -= 1

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/SetHouseWork/ViewController/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/SetHouseWork/ViewController/SetHouseWorkViewController.swift
@@ -143,7 +143,7 @@ final class SetHouseWorkViewController: BaseViewController {
     // MARK: - life cycle
     
     init(houseWorks: [HouseWorksRequest]) {
-        self.houseWorks = [HouseWorksRequest(assignees: [], houseWorkName: "창 청소", space: "LIVINGROOM"), HouseWorksRequest(assignees: [], houseWorkName: "거실 청소", space: "LIVINGROOM"), HouseWorksRequest(assignees: [], houseWorkName: "물건 정리정돈", space: "LIVINGROOM")]
+        self.houseWorks = houseWorks
         super.init(nibName: nil, bundle: nil)
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/WriteHouseWork/ViewController/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/WriteHouseWork/ViewController/WriteHouseWorkViewController.swift
@@ -164,7 +164,7 @@ final class WriteHouseWorkViewController: BaseViewController {
     
     // MARK: - life cycle
     
-    init(houseWorks: [HouseWorksRequest]) {
+    init() {
         self.houseWorks = [HouseWorksRequest(assignees: [], houseWorkName: "", space: "ETC")]
         super.init(nibName: nil, bundle: nil)
     }

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/WriteHouseWork/ViewController/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/WriteHouseWork/ViewController/WriteHouseWorkViewController.swift
@@ -322,7 +322,7 @@ final class WriteHouseWorkViewController: BaseViewController {
     }
     
     private func setDatePicker() {
-        writeHouseWorkCalendarView.spaceLabel.text = "기타 공간"
+        writeHouseWorkCalendarView.spaceLabel.text = TextLiteral.writeHouseWorkViewControllerSpaceLabel
         
         datePickerView.isHidden = true
         datePickerView.setAction()

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/WriteHouseWork/ViewController/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/WriteHouseWork/ViewController/WriteHouseWorkViewController.swift
@@ -322,6 +322,8 @@ final class WriteHouseWorkViewController: BaseViewController {
     }
     
     private func setDatePicker() {
+        writeHouseWorkCalendarView.spaceLabel.text = "기타 공간"
+        
         datePickerView.isHidden = true
         datePickerView.setAction()
         


### PR DESCRIPTION
## 📣 Related Issue
- close #182 

## 👩‍💻 Contents & Screenshot
|<center>홈: 화장실 청송</center>|<center>수정화면에 반영된 모습</center>|
|:---:|:---:|
|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/451f064e-a3af-477e-b93a-6c5ce4fd3e6a" width=200px />|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/83f16556-5f8d-41e3-8698-8cac68191555" width=200px />|

- Home > EditHouseWork: 기존 집안일 바인딩
getHouseWorkById api 연결
홈에서 전달 받은 housework id 를 통해 집안일 정보 콜
컴포넌트에 집안일 정보 반영
집안일 수정/삭제 request 재정리

|<center>공간/세부 집안일 선택</center>|<center>공간/세부 집안일 반영된 모습</center>|
|:---:|:---:|
|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/f23e9101-bf0b-4893-bffb-e114b54d1063" width=200px />|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/eff2fbbc-4f15-47d8-b2b1-7251594eed1f" width=200px />|

- SelectHouseWork > SetHouseWork: 선택한 공간과 세부 집안일 바인딩
SelectHouseWork에서 선택한 공간과 세부 집안일 전달
공간 라벨과 세부 집안일 카드 목록에 정보 반영
+) SetHouseWork에서 세부 집안일을 다 삭제했을 경우 SelectHouseWork으로 돌아가는 로직

|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/568b2c49-d8bd-4232-aa5d-298c09a48079" width=200px />|
|:---:|

- SelectHouseWork > WriteHouseWork: 기타 공간
집안일 직접 입력일 경우 공간 label을 "기타 공간"으로 설정

## 📌 Review Point
```
enum Space: String, CaseIterable {
    case entrance = "현관"
    
    var spaceUpper: String {
        switch self {
        case .entrance:
            return "ENTRANCE"
        }
    }
}
```
- 공간 중 현관의 대문자 버젼을 출력하는 것은 쉽습니다. (Space.entrance.spaceUpper)
하지만 가지고 있는 정보가 ENTRANCE인데 그 정보로부터 "현관"을 끌어오는 것은 쉽게 떠오르지 않았습니다. spaceUpper라는 enum 내 변수가 enum의 case보다 하위 개념이라는 느낌이 들더라구요..

구글링 해본 결과 아래와 같이 enum의 변수에서 enum의 rawValue를 접근할 수 있습니다.
```
Space.allCases.first { $0.spaceUpper == "ENTRANCE" }?.rawValue
```
공간 enum의 모든 case들 중 spaceUpper값이 "ENTRANCE"인 공간 타입들을 찾아서 그중 첫번째 요소의 rawValue를 들고 오라는 의미이다.


## 🔓 Next Step
- 앱 내 알림
