### PR TITLE
[ADD] saveToken API 구현

### DIFF
--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		5AB1B9C329D55FC300DCA8FE /* ToastPaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB1B9C229D55FC300DCA8FE /* ToastPaddingLabel.swift */; };
 		5AB8068629BEE842009EB243 /* UserErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8068529BEE842009EB243 /* UserErrorResponse.swift */; };
 		5ABB7FB229B48DED008D5C15 /* RulesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABB7FB129B48DED008D5C15 /* RulesResponse.swift */; };
+		5ACADCCC2A5559DA00B92C07 /* FCMTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACADCCB2A5559DA00B92C07 /* FCMTokenResponse.swift */; };
 		7E1F2E2528D2123B00A5744A /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 7E1F2E2428D2123B00A5744A /* SnapKit */; };
 		7E1F2E2E28D2168300A5744A /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 7E1F2E2A28D2168200A5744A /* Pretendard-Regular.otf */; };
 		7E1F2E2F28D2168300A5744A /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 7E1F2E2B28D2168200A5744A /* Pretendard-SemiBold.otf */; };
@@ -290,6 +291,7 @@
 		5AB1B9C229D55FC300DCA8FE /* ToastPaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastPaddingLabel.swift; sourceTree = "<group>"; };
 		5AB8068529BEE842009EB243 /* UserErrorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserErrorResponse.swift; sourceTree = "<group>"; };
 		5ABB7FB129B48DED008D5C15 /* RulesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RulesResponse.swift; path = "fairer-iOS/Network/DTO/Rules/RulesResponse.swift"; sourceTree = SOURCE_ROOT; };
+		5ACADCCB2A5559DA00B92C07 /* FCMTokenResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMTokenResponse.swift; sourceTree = "<group>"; };
 		7E1F2E2A28D2168200A5744A /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		7E1F2E2B28D2168200A5744A /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
 		7E1F2E2C28D2168200A5744A /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
@@ -1199,6 +1201,7 @@
 				5A4E711129BEF88B003FD32F /* BlankResponse.swift */,
 				91D4185529EDBF9F00EC2786 /* MemberPatchRequest.swift */,
 				91D4185729EDC18200EC2786 /* MemberPatchResponse.swift */,
+				5ACADCCB2A5559DA00B92C07 /* FCMTokenResponse.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -1381,6 +1384,7 @@
 				5204AAB929507319002FB6CA /* SettingAlarmTableViewCell.swift in Sources */,
 				520D6FF2291133A800CF65B2 /* AlreadyInGroupViewController.swift in Sources */,
 				39F1C12628D5FB4100585B83 /* UILabel+Extension.swift in Sources */,
+				5ACADCCC2A5559DA00B92C07 /* FCMTokenResponse.swift in Sources */,
 				914C69CC29AA0D17008EA9EE /* BaseURLConstant.swift in Sources */,
 				914C69CE29AA2F03008EA9EE /* ErrorResponse.swift in Sources */,
 				5205054728D8626B00355055 /* OnboardingProfileGroupCollectionViewCell.swift in Sources */,

--- a/fairer-iOS/fairer-iOS/Global/Util/UserDefaultHandler.swift
+++ b/fairer-iOS/fairer-iOS/Global/Util/UserDefaultHandler.swift
@@ -19,4 +19,7 @@ struct UserDefaultHandler {
     
     @UserDefault(key: "isLogin", defaultValue: false)
     static var isLogin: Bool
+    
+    @UserDefault(key: "fcmToken", defaultValue: "")
+    static var fcmToken: String
 }

--- a/fairer-iOS/fairer-iOS/Network/API/FcmAPI.swift
+++ b/fairer-iOS/fairer-iOS/Network/API/FcmAPI.swift
@@ -6,3 +6,45 @@
 //
 
 import Foundation
+
+import Moya
+
+final class FcmAPI {
+
+    private let fcmProvider = MoyaProvider<FCMRouter>(plugins: [MoyaLoggerPlugin()])
+    
+    func saveToken(token: String,
+                           completion: @escaping (NetworkResult<Any>) -> Void) {
+        fcmProvider.request(.saveToken(token: token)) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = self.judgeStatus(by: statusCode, data)
+                completion(networkResult)
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+        
+    private func judgeStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        switch statusCode {
+        case 200..<300:
+            guard let decodedData = try? decoder.decode(FCMTokenResponse.self, from: data) else {
+                return .pathErr
+            }
+            return .success(decodedData)
+        case 400..<500:
+            guard let decodedData = try? decoder.decode(ErrorResponse.self, from: data) else {
+                return .pathErr
+            }
+            return .requestErr(decodedData)
+        case 500:
+            return .serverErr
+        default:
+            return .networkFail
+        }
+    }
+}

--- a/fairer-iOS/fairer-iOS/Network/DTO/FCMTokenResponse.swift
+++ b/fairer-iOS/fairer-iOS/Network/DTO/FCMTokenResponse.swift
@@ -1,0 +1,12 @@
+//
+//  FCMTokenResponse.swift
+//  fairer-iOS
+//
+//  Created by 김규철 on 2023/07/05.
+//
+
+import Foundation
+
+struct FCMTokenResponse: Codable {
+    let token: String?
+}

--- a/fairer-iOS/fairer-iOS/Network/Foundation/NetworkService.swift
+++ b/fairer-iOS/fairer-iOS/Network/Foundation/NetworkService.swift
@@ -12,7 +12,7 @@ final class NetworkService {
     
 //    let alarm = AlarmAPI()
 
-//    let fcm = FcmAPI()
+    let fcm = FcmAPI()
 
     let houseWorkCompleteRouter = HouseWorkCompleteRouterAPI()
     

--- a/fairer-iOS/fairer-iOS/Network/Router/FCMRouter.swift
+++ b/fairer-iOS/fairer-iOS/Network/Router/FCMRouter.swift
@@ -6,3 +6,34 @@
 //
 
 import Foundation
+
+import Moya
+
+enum FCMRouter {
+    case saveToken(token: String)
+}
+
+extension FCMRouter: BaseTargetType {
+    var path: String {
+        switch self {
+        case .saveToken:
+            return URLConstant.fcm + "/token"
+        }
+    }
+        
+        var method: Moya.Method {
+            switch self {
+            case .saveToken:
+                return .post
+            }
+        }
+        
+        var task: Moya.Task {
+            switch self {
+            case .saveToken(let token):
+                return .requestParameters(parameters: [
+                    "token": token
+                ], encoding: JSONEncoding.default)
+            }
+        }
+    }

--- a/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
@@ -139,7 +139,7 @@ final class LoginViewController: BaseViewController {
         authorizationController.performRequests()
     }
     
-    func postSignIn(socialType: String) {
+    private func postSignIn(socialType: String) {
         NetworkService.shared.oauth.postSignIn(socialType: socialType) { [weak self] result in
             switch result {
             case .success(let response):
@@ -223,7 +223,7 @@ extension LoginViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
                 print("User Email : \(email ?? "")")
                 print("User Name : \(name)")
                 
-                self.postSignIn(socialType: TextLiteral.clientType)
+                self.postSignIn(socialType: "APPLE")
             default:
                 break
             }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #192 

## 👩‍💻 Contents & Screenshot
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- FCMRouter, FcmAPI에 파일 구현해두었습니다.
- 리스폰스 값으로 fcmToken 값이 넘어오는 거 같아서 해당 값을 저장해두는 userdefaullt 추가해뒀어요

## 📌 Review Point
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
```swift
private func saveFCMToken(token: String) {
        NetworkService.shared.fcm.saveToken(token: token) { result in
            switch result {
            case .success(let response):
                guard let data = response as? FCMTokenResponse else { return }
                
                if let fcmToken = data.token {
                    UserDefaultHandler.fcmToken = fcmToken
                }
            case .requestErr(let errorResponse):
                dump(errorResponse)
                guard let data = errorResponse as? UserErrorResponse else { return }
                print(data.errorMessage)
            default:
                print("sign in error")
            }
        }
    }
```
- 요렇게 사용하려고 했어요 유나님!
- 연결 부탁드립니다 감사해요

## 🧐 Question
<!-- PR 과정에서 생긴 질문을 적어주세요. -->

## 🔓 Next Step
<!-- 다음으로 할 일을 적어주세요. -->
- 

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
