### PR TITLE
[FEAT] 닉네임 정렬 + 글자 수 제한 구현

### DIFF
--- a/fairer-iOS/fairer-iOS/Global/Extension/String+Extension.swift
+++ b/fairer-iOS/fairer-iOS/Global/Extension/String+Extension.swift
@@ -157,5 +157,16 @@ extension String {
         default: return String()
         }
     }
+    
+    func manageNicknameLength() -> String {
+        if self.count >= 5 {
+            var managedNickname = self
+            managedNickname.removeSubrange(self.index(self.startIndex, offsetBy: 4)..<self.endIndex)
+            managedNickname.append("...")
+            return managedNickname
+        } else {
+            return self
+        }
+    }
 }
 

--- a/fairer-iOS/fairer-iOS/Global/Extension/String+Extension.swift
+++ b/fairer-iOS/fairer-iOS/Global/Extension/String+Extension.swift
@@ -162,7 +162,7 @@ extension String {
         if self.count >= 5 {
             var managedNickname = self
             managedNickname.removeSubrange(self.index(self.startIndex, offsetBy: 4)..<self.endIndex)
-            managedNickname.append("...")
+            managedNickname.append("..")
             return managedNickname
         } else {
             return self

--- a/fairer-iOS/fairer-iOS/Global/UIComponent/GetManagerView/GetManagerCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Global/UIComponent/GetManagerView/GetManagerCollectionView.swift
@@ -71,7 +71,7 @@ extension GetManagerCollectionView: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
         
-        guard let memberName = selectedMemberList[indexPath.item].memberName,
+        guard let memberName = selectedMemberList[indexPath.item].memberName?.manageNicknameLength(),
               let memberImage = selectedMemberList[indexPath.item].profilePath else { return UICollectionViewCell() }
         cell.profileImage.load(from: memberImage)
         cell.profileLabel.setTextWithLineHeight(text: memberName, lineHeight: 18)

--- a/fairer-iOS/fairer-iOS/Screens/Group/HouseInfo/View/HouseMemberCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/HouseInfo/View/HouseMemberCollectionView.swift
@@ -71,7 +71,7 @@ extension HouseMemberCollectionView: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
         
-        guard let memberName = teamInfoData[indexPath.row].memberName,
+        guard let memberName = teamInfoData[indexPath.row].memberName?.manageNicknameLength(),
               let memberImage = teamInfoData[indexPath.row].profilePath else { return UICollectionViewCell() }
         
         cell.profileImage.load(from: memberImage)

--- a/fairer-iOS/fairer-iOS/Screens/Group/HouseInfo/ViewController/HouseInfoViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/HouseInfo/ViewController/HouseInfoViewController.swift
@@ -131,7 +131,8 @@ extension HouseInfoViewController {
                 guard let teamName = teamInfo.teamName else { return }
                 
                 DispatchQueue.main.async {
-                    self?.houseMemberCollectionView.teamInfoData = membersInfo
+                    let sortedTeamMember = membersInfo.sorted { $0.memberName ?? "" < $1.memberName ?? "" }
+                    self?.houseMemberCollectionView.teamInfoData = sortedTeamMember
                     self?.houseName = teamName
                 }
             case .requestErr(let error):

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/HomeGroupView/HomeGroupCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/HomeGroupView/HomeGroupCollectionView.swift
@@ -88,7 +88,7 @@ extension HomeGroupCollectionView: UICollectionViewDataSource {
         guard let memberName = userList[indexPath.item].memberName,
               let memberImage = userList[indexPath.item].profilePath else { return UICollectionViewCell() }
         cell.titleImage.load(from: memberImage)
-        cell.titleLabel.text = memberName
+        cell.titleLabel.text = memberName.manageNicknameLength()
         if cell.isSelected == true { cell.onSelected() }
         else { cell.onDeselected() }
         return cell

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -447,8 +447,10 @@ private extension HomeViewController {
             self.selectedMemberId = self.myId
             self.teamId = response.teamId
             self.homewView.homeGroupCollectionView.userList = []
-            if let teamMember = response.members {
-                for member in teamMember {
+            if var teamMember = response.members {
+                let sortedTeamMember = teamMember.sorted { $0.memberName ?? "" < $1.memberName ?? "" }
+                print(sortedTeamMember)
+                for member in sortedTeamMember {
                     if self.myId == member.memberId {
                         self.homewView.homeGroupCollectionView.userList.insert(member, at: 0)
                         self.userName = member.memberName ?? ""

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -449,7 +449,6 @@ private extension HomeViewController {
             self.homewView.homeGroupCollectionView.userList = []
             if let teamMember = response.members {
                 let sortedTeamMember = teamMember.sorted { $0.memberName ?? "" < $1.memberName ?? "" }
-                print(sortedTeamMember)
                 for member in sortedTeamMember {
                     if self.myId == member.memberId {
                         self.homewView.homeGroupCollectionView.userList.insert(member, at: 0)

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -447,7 +447,7 @@ private extension HomeViewController {
             self.selectedMemberId = self.myId
             self.teamId = response.teamId
             self.homewView.homeGroupCollectionView.userList = []
-            if var teamMember = response.members {
+            if let teamMember = response.members {
                 let sortedTeamMember = teamMember.sorted { $0.memberName ?? "" < $1.memberName ?? "" }
                 print(sortedTeamMember)
                 for member in sortedTeamMember {

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/SetHouseWork/ViewController/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/SetHouseWork/ViewController/SetHouseWorkViewController.swift
@@ -22,6 +22,7 @@ final class SetHouseWorkViewController: BaseViewController {
         }
     }
     private var houseWorks: [HouseWorksRequest]
+    private var myId: Int?
     
     // MARK: - property
     
@@ -159,6 +160,7 @@ final class SetHouseWorkViewController: BaseViewController {
         didSelectDaysOfWeek()
         setDoneButton()
         getTeamInfo()
+        getMyInfoFromServer()
     }
     
     override func render() {
@@ -617,14 +619,19 @@ extension SetHouseWorkViewController {
                 guard let teamInfo = response as? TeamInfoResponse else { return }
                 guard let membersInfo = teamInfo.members else { return }
                 DispatchQueue.main.async {
-                    // FIXME: 첫번째 멤버 대신 user item 넣어주기
-                    guard let memberId = membersInfo[0].memberId else { return }
-                    for index in self.houseWorks.indices {
-                        self.houseWorks[index].assignees.append(memberId)
+                    let sortedTeamMember = membersInfo.sorted { $0.memberName ?? "" < $1.memberName ?? "" }
+                    for member in sortedTeamMember {
+                        if let memberId = member.memberId, self.myId == memberId {
+                            for index in self.houseWorks.indices {
+                                self.houseWorks[index].assignees.append(memberId)
+                            }
+                            self.selectManagerView.selectManagerCollectionView.totalMemberList.insert(member, at: 0)
+                            self.getManagerView.getManagerCollectionView.selectedMemberList = [member]
+                            self.selectManagerView.selectManagerCollectionView.selectedManagerList = [member]
+                        } else {
+                            self.selectManagerView.selectManagerCollectionView.totalMemberList.append(member)
+                        }
                     }
-                    self.getManagerView.getManagerCollectionView.selectedMemberList = [membersInfo[0]]
-                    self.selectManagerView.selectManagerCollectionView.totalMemberList = membersInfo
-                    self.selectManagerView.selectManagerCollectionView.selectedManagerList = [membersInfo[0]]
                 }
                 break
             case .requestErr(let errorResponse):
@@ -645,6 +652,20 @@ extension SetHouseWorkViewController {
                 dump(errorResponse)
             default:
                 break
+            }
+        }
+    }
+    
+    private func getMyInfoFromServer() {
+        NetworkService.shared.members.getMemberInfo() { result in
+            switch result {
+            case .success(let response):
+                guard let myInfo = response as? MemberResponse else { return }
+                self.myId = myInfo.memberId
+            case .requestErr(let errResponse):
+                dump(errResponse)
+            default:
+                print("error")
             }
         }
     }

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/SetHouseWork/ViewController/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/SetHouseWork/ViewController/SetHouseWorkViewController.swift
@@ -160,7 +160,7 @@ final class SetHouseWorkViewController: BaseViewController {
         didSelectDaysOfWeek()
         setDoneButton()
         getTeamInfo()
-        getMyInfoFromServer()
+        getMyInfo()
     }
     
     override func render() {
@@ -656,7 +656,7 @@ extension SetHouseWorkViewController {
         }
     }
     
-    private func getMyInfoFromServer() {
+    private func getMyInfo() {
         NetworkService.shared.members.getMemberInfo() { result in
             switch result {
             case .success(let response):


### PR DESCRIPTION
## 📣 Related Issue
- close #194 

## 👩‍💻 Contents & Screenshot
- 하우스 멤버를 보여주는 UI 에서 멤버 목록 정렬 로직을 추가했습니다. (유저 > ㄱㄴㄷ순)
- 하우스 멤버의 닉네임을 4글자까지 표시하고 5글자부터 ... 처리

|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/e09a23f1-6617-4af7-bed0-54f5f1c28cae" width=130px />|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/d7a22607-17a8-49b3-bd3e-ce92b65151d8" width=130px />|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/1336b19c-94e6-4f5c-b656-8c1e69b6b4c4" width=130px />|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/9ab48e82-b386-4ee0-81e9-a483c70c8f50" width=130px />|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/b60c45df-a6c7-4777-b1f3-71d97bf83be2" width=130px />|
|:---:|:---:|:---:|:---:|:---:|
|<center>HomeVC</center>|<center>SetHouseWorkVC</center>|<center>HouseInfoVC</center>|<center>WriteHouseWorkVC</center>|<center>EditHouseWorkVC</center>|


## 📌 Review Point
- 닉네임 글자 수 제한의 경우 ... 으로 표시하기로 논의 되었는데 디자인된 셀 크기에 의하면 4글자 뒤에 ...을 붙히면 줄이 넘어가서 잘리는 현상이 발생합니다. 따라서 ...을 ..으로 줄이는 것으로 닉네임이 잘리는 것을 처리해두었습니다.
- 대면으로도 직접 말씀 드렸지만 닉네임 정렬을 한국어 > 영어로 처리하는 게 너무 복잡해서 디폴트인 영어 > 한국어로 처리해두었습니다.


## 🔓 Next Step
- date picker 날짜 변경 적용하기 