### PR TITLE
[FIX] 자잘자잘한 버그 해결

### DIFF
--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
@@ -213,7 +213,8 @@ final class EditHouseWorkViewController: BaseViewController {
         }
         
         scrollView.snp.makeConstraints {
-            $0.top.leading.trailing.equalToSuperview()
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(doneButton.snp.top).inset(-16)
         }
         

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/SelectHouseWork/View/SelectHouseWorkSpace/SelectHouseWorkSpaceCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/SelectHouseWork/View/SelectHouseWorkSpace/SelectHouseWorkSpaceCollectionView.swift
@@ -12,6 +12,8 @@ import SnapKit
 final class SelectHouseWorkSpaceCollectionView: BaseUIView {
     
     var didTappedSpace: ((Space) -> ())?
+    var showDisableAlert: ((Bool) -> ())?
+    var didChangeSpaceWithHouseWork: Bool = false
     
     private enum Size {
         static let collectionHorizontalSpacing: CGFloat = 24
@@ -33,7 +35,7 @@ final class SelectHouseWorkSpaceCollectionView: BaseUIView {
         flowLayout.itemSize = CGSize(width: Size.cellWidth, height: Size.cellHeight)
         return flowLayout
     }()
-    private lazy var collectionView: UICollectionView = {
+    lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
         collectionView.backgroundColor = .clear
         collectionView.delegate = self
@@ -55,10 +57,13 @@ final class SelectHouseWorkSpaceCollectionView: BaseUIView {
 // MARK: - extension
 
 extension SelectHouseWorkSpaceCollectionView: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        showDisableAlert?(didChangeSpaceWithHouseWork)
+        return !didChangeSpaceWithHouseWork
+    }
+    
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        // FIXME: - api 연결할 때 공간 전달
         didTappedSpace?(Space.allCases[indexPath.item])
-        print(Space.allCases[indexPath.item])
     }
 }
 

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/SelectHouseWork/ViewController/SelectHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/SelectHouseWork/ViewController/SelectHouseWorkViewController.swift
@@ -78,6 +78,7 @@ final class SelectHouseWorkViewController: BaseViewController {
         setDatePicker()
         didTappedSpace()
         didTappedHouseWork()
+        showDisableAlert()
     }
     
     override func render() {
@@ -202,9 +203,9 @@ final class SelectHouseWorkViewController: BaseViewController {
     
     private func didTappedSpace() {
         spaceCollectionView.didTappedSpace = {[weak self] space in
-            self?.didTappedDifferentSpace(space)
             self?.setDetailHouseWork(space)
             self?.setLabels()
+            self?.selectedSpace = space
         }
     }
     
@@ -212,6 +213,7 @@ final class SelectHouseWorkViewController: BaseViewController {
         detailCollectionView.didTappedHouseWork = {[weak self] houseWork in
             if houseWork.count > 0 {
                 self?.nextButton.isDisabled = false
+                self?.spaceCollectionView.didChangeSpaceWithHouseWork = true
             } else {
                 self?.nextButton.isDisabled = true
             }
@@ -219,13 +221,20 @@ final class SelectHouseWorkViewController: BaseViewController {
         }
     }
     
-    private func didTappedDifferentSpace(_ space: Space) {
-        if space != selectedSpace && detailCollectionView.selectedHouseWorkList.count > 0 {
-            makeAlert(title: TextLiteral.selectHouseWorkViewControllerAlertTitle, message: TextLiteral.selectHouseWorkViewControllerAlertMessage)
-            detailCollectionView.selectedHouseWorkList = []
-            nextButton.isDisabled = true
+    private func showDisableAlert() {
+        spaceCollectionView.showDisableAlert = {[weak self] showDisableAlert in
+            if showDisableAlert {
+                self?.makeAlert(title: TextLiteral.selectHouseWorkViewControllerAlertTitle, message: TextLiteral.selectHouseWorkViewControllerAlertMessage, okAction: { [weak self] _ in self?.resetSpace() })
+            }
         }
-        self.selectedSpace = space
+    }
+    
+    private func resetSpace() {
+        detailCollectionView.selectedHouseWorkList = []
+        detailCollectionView.collectionView.reloadData()
+        spaceCollectionView.collectionView.reloadData()
+        nextButton.isDisabled = true
+        spaceCollectionView.didChangeSpaceWithHouseWork = false
     }
     
     private func setDetailHouseWork(_ space: Space) {

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/WriteHouseWork/ViewController/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/WriteHouseWork/ViewController/WriteHouseWorkViewController.swift
@@ -196,7 +196,8 @@ final class WriteHouseWorkViewController: BaseViewController {
         }
         
         scrollView.snp.makeConstraints {
-            $0.top.leading.trailing.equalToSuperview()
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(doneButton.snp.top).inset(-16)
         }
         

--- a/fairer-iOS/fairer-iOS/Screens/Setting/SettingProfileImage/SettingProfileImageViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Setting/SettingProfileImage/SettingProfileImageViewController.swift
@@ -29,7 +29,6 @@ class SettingProfileImageViewController: OnboardingProfileViewController {
         if let lastProfileImage = lastProfileImage {
             profileImageChangeClosure?(lastProfileImage)
         }
-        petchMyInfo()
         self.navigationController?.popViewController(animated: true)
     }
     
@@ -57,28 +56,5 @@ class SettingProfileImageViewController: OnboardingProfileViewController {
         self.firstStatus = status
         self.firstName = name
         self.lastProfileImage = image
-    }
-    
-    private func petchMyInfo() {
-        let memberPatchRequest = MemberPatchRequest(memberName: firstName, profilePath: lastProfileImage, statusMessage: firstStatus)
-        self.petchMemberInfoFromServer(body: memberPatchRequest) { [weak self] response in
-            guard self != nil else { return }
-        }
-    }
-}
-
-extension SettingProfileImageViewController {
-    private func petchMemberInfoFromServer(body: MemberPatchRequest, completion: @escaping (MemberPatchResponse) -> Void) {
-        NetworkService.shared.members.petchMemberInfo(body: body) { result in
-            switch result {
-            case .success(let response):
-                guard let data = response as? MemberPatchResponse else { return }
-                completion(data)
-            case .requestErr(let errorResponse):
-                dump(errorResponse)
-            default:
-                print("error")
-            }
-        }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SettingProfileViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SettingProfileViewController.swift
@@ -134,6 +134,7 @@ final class SettingProfileViewController: BaseViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         isSettingProfileViewPoped = false
+        settingProfileDoneButton.isDisabled = true
     }
     
     override func render() {
@@ -362,6 +363,7 @@ extension SettingProfileViewController {
     private func didTappedDoneButton() {
         self.petchMyInfo()
         self.navigationController?.popViewController(animated: true)
+        self.settingProfileDoneButton.isDisabled = true
     }
     
     private func pushSettingProfileImageViewController() {
@@ -373,6 +375,7 @@ extension SettingProfileViewController {
         }
         settingProfileImageView.profileImageChangeClosure = { [weak self] imageString in
             self?.lastProfileImage = imageString
+            self?.settingProfileDoneButton.isDisabled = false
         }
         settingProfileImageView.settingProfileViewDidPop = { [weak self] didPop in
             self?.isSettingProfileViewPoped = didPop


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #204 

## 👩‍💻 Contents & Screenshot
<!-- 작업 내용과 이미지를 첨부해주세요. -->
[이슈1: [프로필 이미지 변경해도 수정으로 반영 안되는 문제](https://www.notion.so/1626a8a6354b4b379821d4c45c1ccd33)]

https://github.com/fairer-iOS/fairer-iOS/assets/81340603/73ee85b1-60b8-4cdd-ad74-f6e48d7d7ef3

프로필 설정 > 프로필 이미지 변경 > 선택완료 > 입력완료 버튼까지 해야 프로필 정보를 변경할 수 있도록 로직 수정
녹화 영상처럼 프로필 설정 화면에서 입력완료 버튼을 누르지 않고 뒤로 가버리면 수정 내용이 반영되지 않습니다.

[이슈2: [nav bar 에 background Color 적용하기](https://www.notion.so/nav-bar-background-Color-4658804bd75945fa87168378b401601e)]
|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/0cb8ae3a-3f2d-46c6-b196-76d45a8748f4" width=200px />|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/a3118821-b6c0-44d1-95a4-4f7c4b70bd16" width=200px />|
|:---:|:---:|
|<center>WriteHouseWork</center>|<center>EditHouseWork</center>|

scrollView의 top layout을 safe area 기준으로 잡았더니 뒤 배경이 투명해지는 버그가 해결됐습니다.

[이슈3: [세부 집안일 입력 후 다른 공간 선택할시 ux 개선](https://www.notion.so/ux-d8775b0f575642b1a34c30e9a88cb336)]

https://github.com/fairer-iOS/fairer-iOS/assets/81340603/a3c21d34-de13-4333-8485-356614e28263

공간과 세부 집안일이 선택된 상태에서 다른 공간을 터치하면 alert이 뜨고 확인 버튼을 누르면 선택되었던 공간과 세부 집안일이 reset됩니다.


## 📌 Review Point
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- CollectionView에서 특정 조건을 만족할 때만 cell을 선택 가능하도록 하는 로직을 고민했었는데요. 이미 공간과 세부 집안일이 선택되었다면 다른 공간을 선택했을 때 isSelected 가 동작하면 안돼서 관련된 collectionview function이 있는지 찾아봤습니다. didSelectItemAt 전에 동작하는 **shouldSelectItemAt** 은 return 값에 따라 해당 cell의 활성/비활성 을 결정할 수 있습니다. 함께 알면 유용할 것 같아 공유합니다 ~
```swift
    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
        return !didChangeSpaceWithHouseWork
    }
```
didChangeSpaceWithHouseWork이 True면 cell 비활성화 (selection이 안됨)


## 🔓 Next Step
- datepicker 날짜 변경 반영하기
