### PR TITLE
[FIX] 모달 Dismiss & Notification 위치 변경

### DIFF
--- a/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
+++ b/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
@@ -146,6 +146,10 @@ enum TextLiteral {
     static let settingInquiryViewControllerMailBodyText = "문의 내용"
     static let settingInquiryViewControllerAlertTitle = "Mail 앱 연결 실패"
     static let settingInquiryViewControllerAlertMessage = "이메일 설정을 확인하고 다시 시도해주세요."
+    static let settingInquiryViewControllerMailSentAlertTitle = "전송 완료"
+    static let settingInquiryViewControllerMailSentAlertMessage = "빠른 시일 내에 답변 드리겠습니다"
+    static let settingInquiryViewControllerMailFailureAlertTitle = "전송 실패"
+    static let settingInquiryViewControllerMailFailureAlertMessage = "다시 시도해 주세요"
     
     // MARK: - SettingPolicyViewcController
     

--- a/fairer-iOS/fairer-iOS/Screens/Setting/SettingInquiry/ViewController/SettingInquiryViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Setting/SettingInquiry/ViewController/SettingInquiryViewController.swift
@@ -100,4 +100,16 @@ extension SettingInquiryViewController: MFMailComposeViewControllerDelegate {
     private func setupDelegate() {
         composeVC.mailComposeDelegate = self
     }
+    
+    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+        switch result {
+        case .sent, .saved:
+            self.dismiss(animated: true)
+            self.makeAlert(title: TextLiteral.settingInquiryViewControllerMailSentAlertTitle, message: TextLiteral.settingInquiryViewControllerMailSentAlertMessage)
+        case .cancelled, .failed:
+            self.makeAlert(title: TextLiteral.settingInquiryViewControllerMailFailureAlertTitle, message: TextLiteral.settingInquiryViewControllerMailFailureAlertMessage)
+        default:
+            self.dismiss(animated: true)
+        }
+    }
 }

--- a/fairer-iOS/fairer-iOS/Screens/SettingProfileViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/SettingProfileViewController.swift
@@ -120,12 +120,13 @@ final class SettingProfileViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupDelegation()
-        setupNotificationCenter()
         setButtomAction()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        
+        setupNotificationCenter()
         if isSettingProfileViewPoped == false {
             getMyInfo()
         }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #219 

## 👩‍💻 Contents & Screenshot
- 문의하기 화면에서 메일을 보낸 후 모달이 내려가지 않는 버그 해결 + UX 개선을 위해 alert 추가

https://github.com/fairer-iOS/fairer-iOS/assets/81340603/86b8b96f-a447-4045-b82e-e3def7c53a35

<img width="679" alt="스크린샷 2023-07-18 오후 1 23 23" src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/dc22248e-85c3-4c97-bf29-cceb2ca398d8">

(디폴트 수신 계정은 fairer 계정입니다)

- 이전 화면에 나갔다 들어오면 Notification Center가 동작하지 않아 버튼이 올라오지 않는 버그 해결

https://github.com/fairer-iOS/fairer-iOS/assets/81340603/4d6d3ede-57fc-4278-b152-9389f6c57503


## 📌 Review Point
- 메일 전송 성공 여부에 따라 다른 action을 처리할 수 있음
```swift
func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
    switch result {
        case .sent, .saved, .cancelled, .failed: // 상태에 따라 분기 처리 가능
    }
}
```
- 화면을 나갔다 들어왔을 때 Notification Center가 동작하지 않은 이유는 viewDidLoad에 setting 함수가 있었기 때문입니다. 한 번 로드된 이후에 실행되지 않기 때문에 당연하게.. 동작하지 않았을 겁니다 .. (머쓱) 매번 화면을 보여주기 전에 Notification을 setting 할 수 있도록 viewWillAppear 에 넣어두었습니다!


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- [Swift ) Mail 앱으로 메일 보내기(MessageUI)](https://eeyatho.tistory.com/65)