### PR TITLE
[FIX] 하우스 이름 수정 textfield 버그 해결

### DIFF
--- a/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
+++ b/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
@@ -14,6 +14,7 @@ enum TextLiteral {
     static let doneButtonText: String = "입력 완료"
     static let textFieldDisableSignLabel: String = "&,!,#,@,^와 같은 특수문자는 입력하실 수 없어요."
     static let textFieldWarningOverFive: String = "텍스트는 5글자를 초과하여 입력하실 수 없어요."
+    static let textFieldWarningOverSixteen: String = "텍스트는 16글자를 초과하여 입력하실 수 없어요."
     static let textFieldWarningOverTwenty: String = "텍스트는 20글자를 초과하여 입력하실 수 없어요."
     static let setManagerToastLabel = "집안일 담당자를 지정해주세요."
     static let setTimeLabel = "시간설정"

--- a/fairer-iOS/fairer-iOS/Global/UIComponent/TextField.swift
+++ b/fairer-iOS/fairer-iOS/Global/UIComponent/TextField.swift
@@ -70,6 +70,7 @@ final class TextField: UITextField {
     private func configUI() {
         self.backgroundColor = .normal0
         self.font = type.font
+        self.textColor = .gray800
         self.layer.cornerRadius = 8
         self.autocorrectionType = .no
         self.autocapitalizationType = .none

--- a/fairer-iOS/fairer-iOS/Screens/Setting/ChangeHouseName/ChangeHouseNameViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Setting/ChangeHouseName/ChangeHouseNameViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 final class ChangeHouseNameViewController: BaseViewController {
     
     private var isNameSatisfied = true
+    private var lastName: String?
     
     // MARK: - property
     
@@ -145,16 +146,11 @@ final class ChangeHouseNameViewController: BaseViewController {
     
     private func didTapDoneButton() {
         guard let text = houseNameTextField.text else { return }
-        
-        if houseNameTextField.text!.hasCharacters() {
-            houseNameTextField.layer.borderWidth = 0
+        patchTeamInfo(teamName: text)
+    }
     
-            patchTeamInfo(teamName: text)
-        } else {
-            houseNameTextField.layer.borderWidth = 1
-            houseNameTextField.layer.borderColor = UIColor.negative20.cgColor
-            changeHouseNameDoneButton.isDisabled = true
-        }
+    private func checkDoneButton() {
+        changeHouseNameDoneButton.isDisabled = !isNameSatisfied || lastName == houseNameTextField.text
     }
     
     private func checkTextField() {
@@ -179,6 +175,7 @@ final class ChangeHouseNameViewController: BaseViewController {
 extension ChangeHouseNameViewController : UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
         checkTextField()
+        checkDoneButton()
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -208,6 +205,7 @@ extension ChangeHouseNameViewController {
                 guard let teamName = teamInfo.teamName else { return }
                 DispatchQueue.main.async {
                     self.houseNameTextField.text = teamName
+                    self.lastName = teamName
                 }
                 break
             case .requestErr(let errorResponse):

--- a/fairer-iOS/fairer-iOS/Screens/Setting/ChangeHouseName/ChangeHouseNameViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Setting/ChangeHouseName/ChangeHouseNameViewController.swift
@@ -45,7 +45,7 @@ final class ChangeHouseNameViewController: BaseViewController {
     }()
     private let houseNameNumWarningLabel: UILabel = {
         let label = UILabel()
-        label.text = TextLiteral.textFieldWarningOverTwenty
+        label.text = TextLiteral.textFieldWarningOverSixteen
         label.textColor = .negative20
         label.font = .body2
         label.numberOfLines = 0
@@ -98,7 +98,7 @@ final class ChangeHouseNameViewController: BaseViewController {
         
         view.addSubview(changeHouseNameStackView)
         changeHouseNameStackView.snp.makeConstraints {
-            $0.top.equalTo(houseNameTextField.snp.bottom).offset(6)
+            $0.top.equalTo(houseNameTextField.snp.bottom).offset(8)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         

--- a/fairer-iOS/fairer-iOS/Screens/Setting/ChangeHouseName/ChangeHouseNameViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Setting/ChangeHouseName/ChangeHouseNameViewController.swift
@@ -55,6 +55,7 @@ final class ChangeHouseNameViewController: BaseViewController {
         super.viewDidLoad()
         setupDelegation()
         setupNotificationCenter()
+        getTeamInfo()
     }
     
     override func render() {
@@ -167,7 +168,7 @@ extension ChangeHouseNameViewController : UITextFieldDelegate {
 }
 
 extension ChangeHouseNameViewController {
-    func patchTeamInfo(teamName: String) {
+    private func patchTeamInfo(teamName: String) {
         NetworkService.shared.teams.patchTeamInfo(teamName: teamName) { [weak self] result in
             switch result {
             case .success(_):
@@ -176,6 +177,24 @@ extension ChangeHouseNameViewController {
                 dump(error)
             default:
                 print("server error")
+            }
+        }
+    }
+    
+    private func getTeamInfo() {
+        NetworkService.shared.teams.getTeamInfo { result in
+            switch result {
+            case .success(let response):
+                guard let teamInfo = response as? TeamInfoResponse else { return }
+                guard let teamName = teamInfo.teamName else { return }
+                DispatchQueue.main.async {
+                    self.houseNameTextField.text = teamName
+                }
+                break
+            case .requestErr(let errorResponse):
+                dump(errorResponse)
+            default:
+                break
             }
         }
     }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #225 

## 👩‍💻 Contents & Screenshot

|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/2248dca3-88f4-4143-993f-f2e65ee8c993" width=150px />|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/d0402cd1-6243-4afc-bbf6-776cdcc644db" width=150px />|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/8cc914a4-7fba-41a2-9e71-e928a328781a" width=150px />|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/85459446-95bc-4611-a4d8-ea8cd2940f7e" width=150px />|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/8d62e727-e0fb-4952-b047-8d3b1893a577" width=150px />|
|:---:|:---:|:---:|:---:|:---:|
|<center>초기</center>|<center>특수문자</center>|<center>16자 초과</center>|<center>둘 다</center>|<center>올바르게 입력</center>|

## 📌 Review Point
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- 전에는 버튼을 눌렀을 때 글자수가 초과되었고, 이모티콘을 사용했음을 확인할 수 있는 로직이었는데, 입력할 때마다 글자수를 충족하고 특수문자를 사용하지 않는지 확인하는 로직으로 업데이트 되어서 같이 반영했씁니당 ㅎㅎ
