### PR TITLE
[FIX] 다른 공간 선택시 세부 집안일 목록 숨기기 

### DIFF
--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
@@ -730,8 +730,7 @@ extension EditHouseWorkViewController {
     private func putEditHouseWork(body: EditHouseWorkRequest) {
         NetworkService.shared.houseWorks.putEditHouseWork(body: body) { result in
             switch result {
-            case .success(let response):
-                dump(response)
+            case .success(_):
                 break
             case .requestErr(let errorResponse):
                 dump(errorResponse)
@@ -744,8 +743,7 @@ extension EditHouseWorkViewController {
     private func deleteHouseWork(body: DeleteHouseWorkRequest) {
         NetworkService.shared.houseWorks.deleteHouseWork(body: body) { result in
             switch result {
-            case .success(let response):
-                dump(response)
+            case .success(_):
                 break
             case .requestErr(let errorResponse):
                 dump(errorResponse)
@@ -765,7 +763,6 @@ extension EditHouseWorkViewController {
                         self.setLatestContents()
                     }
                 }
-                dump(response)
             case .requestErr(let errorResponse):
                 dump(errorResponse)
             default:

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/SelectHouseWork/ViewController/SelectHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/SelectHouseWork/ViewController/SelectHouseWorkViewController.swift
@@ -232,9 +232,22 @@ final class SelectHouseWorkViewController: BaseViewController {
     }
     
     private func resetSpace() {
-        detailCollectionView.selectedHouseWorkList = []
-        detailCollectionView.collectionView.reloadData()
         spaceCollectionView.collectionView.reloadData()
+        
+        spaceInfoLabel.isHidden = false
+        
+        detailHouseWorkLabel.isHidden = true
+        detailHouseWorkLabel.snp.updateConstraints {
+            $0.height.equalTo(0)
+        }
+        
+        detailCollectionView.selectedHouseWorkList = []
+        detailCollectionView.snp.updateConstraints {
+            $0.height.equalTo(0)
+        }
+        
+        writeHouseWorkLabel.isHidden = true
+        
         nextButton.isDisabled = true
         spaceCollectionView.didChangeSpaceWithHouseWork = false
     }

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/SelectHouseWork/ViewController/SelectHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/SelectHouseWork/ViewController/SelectHouseWorkViewController.swift
@@ -232,8 +232,6 @@ final class SelectHouseWorkViewController: BaseViewController {
     }
     
     private func resetSpace() {
-        spaceCollectionView.collectionView.reloadData()
-        
         spaceInfoLabel.isHidden = false
         
         detailHouseWorkLabel.isHidden = true
@@ -247,6 +245,12 @@ final class SelectHouseWorkViewController: BaseViewController {
         }
         
         writeHouseWorkLabel.isHidden = true
+        
+        UIView.animate(withDuration: 0.6, delay: 0, options: .transitionCurlUp, animations: {
+            self.view.layoutIfNeeded()
+        }, completion: nil)
+        
+        spaceCollectionView.collectionView.reloadData()
         
         nextButton.isDisabled = true
         spaceCollectionView.didChangeSpaceWithHouseWork = false

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/SetHouseWork/ViewController/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/SetHouseWork/ViewController/SetHouseWorkViewController.swift
@@ -657,8 +657,7 @@ extension SetHouseWorkViewController {
     private func postAddHouseWorks(body: [HouseWorksRequest]) {
         NetworkService.shared.houseWorks.postAddHouseWorksAPI(body: body) { result in
             switch result {
-            case .success(let response):
-                dump(response)
+            case .success(_):
                 break
             case .requestErr(let errorResponse):
                 dump(errorResponse)

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/WriteHouseWork/ViewController/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/WriteHouseWork/ViewController/WriteHouseWorkViewController.swift
@@ -632,8 +632,7 @@ extension WriteHouseWorkViewController {
     private func postAddHouseWorks(body: [HouseWorksRequest]) {
         NetworkService.shared.houseWorks.postAddHouseWorksAPI(body: body) { result in
             switch result {
-            case .success(let response):
-                dump(response)
+            case .success(_):
                 break
             case .requestErr(let errorResponse):
                 dump(errorResponse)

--- a/fairer-iOS/fairer-iOS/Screens/Setting/SettingAlarm/ViewController/SettingAlarmViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Setting/SettingAlarm/ViewController/SettingAlarmViewController.swift
@@ -106,7 +106,7 @@ extension SettingAlarmViewController {
     func putAlarmStatus(body: AlarmRequest) {
         NetworkService.shared.alarm.putAlarmStatus(body: body) { result in
             switch result {
-            case .success(let response):
+            case .success(_):
                 break
             case .requestErr(let errorResponse):
                 dump(errorResponse)


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #227 

## 👩‍💻 Contents & Screenshot

https://github.com/fairer-iOS/fairer-iOS/assets/81340603/9ca56eb6-f27a-4c02-bca0-9244a9f9bf53

공간과 세부 집안일 선택 후 다른 공간을 선택했을 때 나오는 얼럿의 확인 버튼을 누를 경우
공간과 세부 집안일이 초기화 되는데 이때 세부 집안일 목록이 hidden 처리 되어야 합니다..
지난 버그 픽스 때 인지하지 못해서 수정 후 피알 올립니당

그 김에 api 통신에서 사용하던 dump를 일부 삭제했습니당 (moya logger 가 이미 잘 프린트 해주고 있기 때문!)