### PR TITLE
[ADD] 회원탈퇴 구현 + 관련 버그 수정

### DIFF
--- a/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
+++ b/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
@@ -116,6 +116,11 @@ enum TextLiteral {
     static let settingViewControllerVersionLabel: String = "버전"
     static let settingViewControllerVersionText: String = "1.0.0"
     static let settingViewControllerLogoutButtonText: String = "로그아웃"
+    static let settingViewControllerLeaveButtonText: String = "회원탈퇴"
+    static let settingViewControllerLogoutAlertTitle: String = "로그아웃 하시겠습니까?"
+    static let settingViewControllerAlertOkTitle: String = "로그아웃"
+    static let settingViewControllerLeaveAlertTitle: String = "회원탈퇴 하시겠습니까?"
+    static let settingViewControllerLeaveAlertMessage: String = "모든 집안일 정보가 사라지며,\n되돌릴 수 없습니다."
     
     // MARK: - ManageHouseViewController
     

--- a/fairer-iOS/fairer-iOS/Screens/Group/EnterHouse/EnterHouseViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/EnterHouse/EnterHouseViewController.swift
@@ -174,20 +174,10 @@ extension EnterHouseViewController {
         let moveToHouseInfoViewAction = UIAction { [weak self] _ in
             self?.moveToHouseInfoView()
         }
-        let toastAction = UIAction { [weak self] _ in
-            self?.touchUpToShowToast()
-        }
-        
-        self.enterHouseDoneButton.addAction(toastAction, for: .touchUpInside)
         self.enterHouseDoneButton.addAction(moveToHouseInfoViewAction, for: .touchUpInside)
     }
     
     private func moveToHouseInfoView() {
-        let houseInfoViewController = HouseInfoViewController()
-        self.navigationController?.pushViewController(houseInfoViewController, animated: true)
-    }
-    
-    private func touchUpToShowToast() {
         guard let inviteCode = enterHouseCodeTextfield.text else { return }
         postJoinTeam(inviteCode: inviteCode)
     }

--- a/fairer-iOS/fairer-iOS/Screens/Group/GroupMain/GroupMainViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/GroupMain/GroupMainViewController.swift
@@ -21,7 +21,6 @@ final class GroupMainViewController: BaseViewController {
             }
         }
     }
-    private let backButton = BackButton()
     private var titleLabel: UILabel = {
         let label = UILabel()
         label.font = .h2
@@ -84,6 +83,7 @@ final class GroupMainViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setButtonAction()
+        getMyInfoFromServer()
     }
 
     override func render() {
@@ -145,11 +145,8 @@ final class GroupMainViewController: BaseViewController {
     override func setupNavigationBar() {
         super.setupNavigationBar()
         
-        let backButton = makeBarButtonItem(with: backButton)
-        
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationItem.largeTitleDisplayMode = .never
-        navigationItem.leftBarButtonItem = backButton
     }
 
     func setUserName(name: String) {
@@ -181,5 +178,23 @@ extension GroupMainViewController {
     private func moveToHouseEnterView() {
         let houseEnterViewController = EnterHouseViewController()
         self.navigationController?.pushViewController(houseEnterViewController, animated: true)
+    }
+}
+
+// MARK: - api
+
+extension GroupMainViewController {
+    private func getMyInfoFromServer() {
+        NetworkService.shared.members.getMemberInfo { result in
+            switch result {
+            case .success(let response):
+                guard let data = response as? MemberResponse else { return }
+                self.userName = data.memberName
+            case .requestErr(let errorResponse):
+                dump(errorResponse)
+            default:
+                print("error")
+            }
+        }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/Setting/SettingMain/ViewController/SettingViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Setting/SettingMain/ViewController/SettingViewController.swift
@@ -65,6 +65,22 @@ final class SettingViewController: BaseViewController {
         view.backgroundColor = .gray100
         return view
     }()
+    private lazy var leaveButton: UIButton = {
+        let button = UIButton()
+        button.setTitle(TextLiteral.settingViewControllerLeaveButtonText, for: .normal)
+        button.setTitleColor(.negative20, for: .normal)
+        button.titleLabel?.font = .body2
+        let action = UIAction { [weak self] _ in
+            self?.touchUpToLeave()
+        }
+        button.addAction(action, for: .touchUpInside)
+        return button
+    }()
+    private let leaveDivider: UIView = {
+       let view = UIView()
+        view.backgroundColor = .gray100
+        return view
+    }()
     
     // MARK: - life cycle
     
@@ -114,6 +130,20 @@ final class SettingViewController: BaseViewController {
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
             $0.height.equalTo(1)
         }
+        
+        view.addSubview(leaveButton)
+        leaveButton.snp.makeConstraints {
+            $0.top.equalTo(logoutDivider).offset(17)
+            $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.height.equalTo(22)
+        }
+        
+        view.addSubview(leaveDivider)
+        leaveDivider.snp.makeConstraints {
+            $0.top.equalTo(leaveButton.snp.bottom).offset(17)
+            $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
+            $0.height.equalTo(1)
+        }
     }
     
     // MARK: - func
@@ -142,7 +172,7 @@ final class SettingViewController: BaseViewController {
     }
     
     private func touchUpToLogout() {
-        self.makeRequestAlert(title: "로그아웃 하시겠습니까?", message: "", okTitle: "로그아웃") { [weak self] _ in
+        self.makeRequestAlert(title: TextLiteral.settingViewControllerLogoutAlertTitle, message: "", okTitle: TextLiteral.settingViewControllerAlertOkTitle) { [weak self] _ in
             self?.postLogout()
         }
     }
@@ -152,6 +182,12 @@ final class SettingViewController: BaseViewController {
             UserDefaults.standard.removePersistentDomain(forName: bundleID)
         }
         RootHandler.shared.change(root: .login)
+    }
+    
+    private func touchUpToLeave() {
+        self.makeRequestAlert(title: TextLiteral.settingViewControllerLeaveAlertTitle, message: TextLiteral.settingViewControllerLeaveAlertMessage, okTitle: TextLiteral.settingViewControllerLeaveButtonText) { [weak self] _ in
+            self?.postLogout()
+        }
     }
 }
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #232 

## 👩‍💻 Contents & Screenshot
<!-- 작업 내용과 이미지를 첨부해주세요. -->
[회원탈퇴 구현]

https://github.com/fairer-iOS/fairer-iOS/assets/81340603/a48c40e5-eaf4-4193-9394-109857167615

- api가 완성되지 않아서 로그아웃과 동일한 로직으로 일단 추가해두었습니다!

[GroupMain의 버그 픽스]

https://github.com/fairer-iOS/fairer-iOS/assets/81340603/16a833ad-d110-493c-a8bf-2df5119028fe

- 뒤로 가기 버튼 삭제
- 닉네임 표시 안되는 문제 해결 (원래는 OnboardingName에서 입력한 이름을 parameter 로 전달했었음, 설정에서 넘어올 때는 OnboardingName을 거치지 않으므로 api를 연결하여 닉네임 정보를 불러옴)
- 하우스 참여 후 화면이 두 개 얹어지는 문제 해결 (push를 두 번하고 있어서 하나로 줄였어용)


## 📌 Review Point
GroupMain에서 앱을 나간 후 다시 들어오면 SceneDelegate 에서 login 뷰컨으로 navigate 하는 문제가 발견되었습니다~ 이와 관련해서는 규철님이 해결하고 계시니까 테스트 할 때 GroupMain에서 다시 빌드하거나.. 앱을 나가지 마시길 참고 부탁드립니다 ~