### PR TITLE
[FIX] 팀 참가하지 않은 유저 분기처리

### DIFF
--- a/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
+++ b/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
@@ -22,11 +22,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: windowScene)
         window?.makeKeyAndVisible()
                 
-        if UserDefaultHandler.isLogin == true && UserDefaultHandler.hasTeam == true {
+        if UserDefaultHandler.isLogin && UserDefaultHandler.hasTeam {
             RootHandler.shared.change(root: .Home)
-        } else if UserDefaultHandler.isLogin == true && UserDefaultHandler.hasTeam == false {
+        } else if UserDefaultHandler.isLogin && !UserDefaultHandler.hasTeam {
             RootHandler.shared.change(root: .groupMain)
-        } else if UserDefaultHandler.isLogin == false {
+        } else if !UserDefaultHandler.isLogin {
             RootHandler.shared.change(root: .login)
         }
     }

--- a/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
+++ b/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
@@ -16,16 +16,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     private var networkMonitor: NetworkMonitor = NetworkMonitor()
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        
         startMonitoringNetwork(on: scene)
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         window?.makeKeyAndVisible()
-        
-        guard UserDefaultHandler.isLogin == true else {
+                
+        if UserDefaultHandler.isLogin == true && UserDefaultHandler.hasTeam == true {
+            RootHandler.shared.change(root: .Home)
+        } else if UserDefaultHandler.isLogin == true && UserDefaultHandler.hasTeam == false {
+            RootHandler.shared.change(root: .groupMain)
+        } else if UserDefaultHandler.isLogin == false {
             RootHandler.shared.change(root: .login)
-            return
         }
-        RootHandler.shared.change(root: .Home)
     }
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {

--- a/fairer-iOS/fairer-iOS/Global/Util/RootHandler.swift
+++ b/fairer-iOS/fairer-iOS/Global/Util/RootHandler.swift
@@ -13,6 +13,7 @@ final class RootHandler {
     enum Root {
         case login
         case Home
+        case groupMain
     }
     
     func change(root: Root) {
@@ -30,6 +31,12 @@ final class RootHandler {
             // MARK: - Home 뷰로 이동
             sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: homeViewController)
             homeViewController.navigationController?.setViewControllers([homeViewController], animated: true)
+            
+        case .groupMain:
+            let groupMainViewController = GroupMainViewController()
+            // MARK: - 그룹 참여 뷰로 이동
+            sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: groupMainViewController)
+            groupMainViewController.navigationController?.setViewControllers([groupMainViewController], animated: true)
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Global/Util/UserDefaultHandler.swift
+++ b/fairer-iOS/fairer-iOS/Global/Util/UserDefaultHandler.swift
@@ -20,6 +20,9 @@ struct UserDefaultHandler {
     @UserDefault(key: "isLogin", defaultValue: false)
     static var isLogin: Bool
     
+    @UserDefault(key: "hasTeam", defaultValue: false)
+    static var hasTeam: Bool
+    
     @UserDefault(key: "fcmToken", defaultValue: "")
     static var fcmToken: String
 }

--- a/fairer-iOS/fairer-iOS/Network/API/OauthAPI.swift
+++ b/fairer-iOS/fairer-iOS/Network/API/OauthAPI.swift
@@ -11,7 +11,7 @@ import Moya
 
 final class OauthAPI {
 
-    private let authProvider = MoyaProvider<OauthRouter>(session : Moya.Session(interceptor: Interceptor()), plugins: [MoyaLoggerPlugin()])
+    private let authProvider = MoyaProvider<OauthRouter>(plugins: [MoyaLoggerPlugin()])
     
     func postSignIn(socialType: String,
                            completion: @escaping (NetworkResult<Any>) -> Void) {

--- a/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
@@ -152,14 +152,14 @@ final class LoginViewController: BaseViewController {
                 
                 guard let isNewMember = data.isNewMember, let hasTeam = data.hasTeam, let userName = data.memberName else { return }
                 
-                if isNewMember == false && hasTeam == true {
+                if !isNewMember && hasTeam {
                     UserDefaultHandler.hasTeam = true
                     RootHandler.shared.change(root: .Home)
-                } else if isNewMember == false && hasTeam == false {
+                } else if !isNewMember && !hasTeam {
                     let groupMainViewController = GroupMainViewController()
                     groupMainViewController.setUserName(name: userName)
                     RootHandler.shared.change(root: .groupMain)
-                } else if isNewMember == true && hasTeam == false  {
+                } else if isNewMember && !hasTeam  {
                     let onBoardingNameViewController = OnboardingNameViewController()
                     self?.navigationController?.setViewControllers([onBoardingNameViewController], animated: true)
                 }

--- a/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
@@ -150,12 +150,19 @@ final class LoginViewController: BaseViewController {
                 }
                 UserDefaultHandler.isLogin = true
                 
-                guard let isNewMember = data.isNewMember, isNewMember == true else {
-                    RootHandler.shared.change(root: .Home)
-                    return }
+                guard let isNewMember = data.isNewMember, let hasTeam = data.hasTeam, let userName = data.memberName else { return }
                 
-                let onBoardingNameViewController = OnboardingNameViewController()
-                self?.navigationController?.setViewControllers([onBoardingNameViewController], animated: true)
+                if isNewMember == false && hasTeam == true {
+                    UserDefaultHandler.hasTeam = true
+                    RootHandler.shared.change(root: .Home)
+                } else if isNewMember == false && hasTeam == false {
+                    let groupMainViewController = GroupMainViewController()
+                    groupMainViewController.setUserName(name: userName)
+                    RootHandler.shared.change(root: .groupMain)
+                } else if isNewMember == true && hasTeam == false  {
+                    let onBoardingNameViewController = OnboardingNameViewController()
+                    self?.navigationController?.setViewControllers([onBoardingNameViewController], animated: true)
+                }
             case .requestErr(let errorResponse):
                 dump(errorResponse)
                 guard let data = errorResponse as? UserErrorResponse else { return }

--- a/fairer-iOS/fairer-iOS/Screens/Group/EnterHouse/EnterHouseViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/EnterHouse/EnterHouseViewController.swift
@@ -155,6 +155,7 @@ extension EnterHouseViewController {
         NetworkService.shared.teams.postJoinTeam(inviteCode: inviteCode) { [weak self] result in
             switch result {
             case .success:
+                UserDefaultHandler.hasTeam = true
                     self?.navigationController?.pushViewController(HouseInfoViewController(), animated: true)
             case .requestErr(let error):
                 guard let errorResponse = error as? UserErrorResponse else { return }

--- a/fairer-iOS/fairer-iOS/Screens/Group/HouseMakeName/HouseMakeNameViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/HouseMakeName/HouseMakeNameViewController.swift
@@ -152,6 +152,8 @@ extension HouseMakeNameViewController {
         NetworkService.shared.teams.postAddTeam(teamName: teamName) { result in
             switch result {
             case .success(let response):
+                UserDefaultHandler.hasTeam = true
+                
                 guard let addPostTeamData = response as? AddTeamResponse else { return }
                 completion(addPostTeamData)
             case .requestErr(let error):

--- a/fairer-iOS/fairer-iOS/Screens/Setting/ManageHouse/ManageHouseViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Setting/ManageHouse/ManageHouseViewController.swift
@@ -204,6 +204,7 @@ extension ManageHouseViewController {
         NetworkService.shared.teams.postLeaveTeam { [weak self] result in
             switch result {
             case .success(_):
+                UserDefaultHandler.hasTeam = false
                 let pushVC = GroupMainViewController()
                 if let navigationController = self?.navigationController {
                     navigationController.setViewControllers([pushVC], animated: true)


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #233 

- 팀 참가하지 않은 유저를 분기처리를 scene과 로그인vc에서 진행해봤습니다.

## 👩‍💻 Contents & Screenshot
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- 기존에는 로그인 여부만 확인했지만, 회원가입 이후 팀을 나갔거나, 온보딩에서 팀을 설정할 때 앱이 종료된 경우를 미리 확인하지 못했습니다.
- 그래서 총 3가지 유저로 분기를 생각해봤습니다.

[로그인 시]
1. 신규유저가 아니면서, 팀에 참가한 유저 -> 흠으로
2. 신규유저가 아니면서, 팀에 참가하지 않은 유저 -> 그룹 메인으로 (팀을 나갔거나, 온보딩 팀 설정 중 앱을 종료)
3. 신규유저면서, 팀에 참가하지 않은 유저 -> 온보딩 뷰로 (사실 신규유저가 팀에 참가했는지 안했는지 확인할 필요가 없지만.. 혹시 몰라서 설정해두었습니다.)

[앱 접속 시]
1. 로그인한 유저면서, 팀에 참가한 유저 -> 홈으로
2. 로그인한 유저면서, 팀에 참가하지 않은 유저 -> 그룹메인으로
3. 로그인하지 않은 유저 -> 로그인뷰로 **(로그인뷰로 이동 후 로그인 시 한번 더 hasTeam을 확인합니다.)**

## 📌 Review Point
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- 테스트가 많이 필요할 거 같습니다..

