### PR TITLE
[FIX] 이미지 파싱 로직 수정

### DIFF
--- a/fairer-iOS/fairer-iOS/Global/Extension/UIImageView+Extension.swift
+++ b/fairer-iOS/fairer-iOS/Global/Extension/UIImageView+Extension.swift
@@ -31,26 +31,31 @@ extension UIImageView {
     }
     
     func load(from url: String) {
-        let firstImageURL = url.components(separatedBy: "Fic_")[1]
-        let finalImageURL = firstImageURL.components(separatedBy: ".svg")[0]
+        let firstImageURL = url.components(separatedBy: "2F")[1]
+        var finalImageURL = ""
+        if firstImageURL.contains("-3x") {
+            finalImageURL = firstImageURL.components(separatedBy: "-3x")[0]
+        } else {
+            finalImageURL = firstImageURL.components(separatedBy: ".svg")[0]
+        }
         switch finalImageURL {
-        case "profile1": self.image = ImageLiterals.profileBlue3
-        case "profile2": self.image = ImageLiterals.profileBlue4
-        case "profile3": self.image = ImageLiterals.profilePink1
-        case "profile4": self.image = ImageLiterals.profileOrange1
-        case "profile5": self.image = ImageLiterals.profilePink3
-        case "profile6": self.image = ImageLiterals.profilePurple1
-        case "profile7": self.image = ImageLiterals.profilePurple2
-        case "profile8": self.image = ImageLiterals.profilePurple3
-        case "profile9": self.image = ImageLiterals.profileOrange2
-        case "profile10": self.image = ImageLiterals.profileYellow2
-        case "profile11": self.image = ImageLiterals.profileIndigo3
-        case "profile12": self.image = ImageLiterals.profileGreen1
-        case "profile13": self.image = ImageLiterals.profileYellow1
-        case "profile14": self.image = ImageLiterals.profileGreen3
-        case "profile15": self.image = ImageLiterals.profileLightBlue1
-        case "profile16": self.image = ImageLiterals.profileLightBlue2
-        default: return
+        case "ic_profile1", "blue3": self.image = ImageLiterals.profileBlue3
+        case "ic_profile2", "blue4": self.image = ImageLiterals.profileBlue4
+        case "ic_profile3", "pink1": self.image = ImageLiterals.profilePink1
+        case "ic_profile4", "orange1": self.image = ImageLiterals.profileOrange1
+        case "ic_profile5", "pink3": self.image = ImageLiterals.profilePink3
+        case "ic_profile6", "purple1": self.image = ImageLiterals.profilePurple1
+        case "ic_profile7", "purple2": self.image = ImageLiterals.profilePurple2
+        case "ic_profile8", "purple3": self.image = ImageLiterals.profilePurple3
+        case "ic_profile9", "orange2": self.image = ImageLiterals.profileOrange2
+        case "ic_profile10", "yellow2": self.image = ImageLiterals.profileYellow2
+        case "ic_profile11", "indigo3": self.image = ImageLiterals.profileIndigo3
+        case "ic_profile12", "green1": self.image = ImageLiterals.profileGreen1
+        case "ic_profile13", "yellow1": self.image = ImageLiterals.profileYellow1
+        case "ic_profile14", "green3": self.image = ImageLiterals.profileGreen3
+        case "ic_profile15", "blue1": self.image = ImageLiterals.profileLightBlue1
+        case "ic_profile16", "blue2": self.image = ImageLiterals.profileLightBlue2
+        default: self.image = ImageLiterals.profileBlue3
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Global/Extension/UIImageView+Extension.swift
+++ b/fairer-iOS/fairer-iOS/Global/Extension/UIImageView+Extension.swift
@@ -31,12 +31,14 @@ extension UIImageView {
     }
     
     func load(from url: String) {
-        let firstImageURL = url.components(separatedBy: "2F")[1]
         var finalImageURL = ""
-        if firstImageURL.contains("-3x") {
-            finalImageURL = firstImageURL.components(separatedBy: "-3x")[0]
-        } else {
-            finalImageURL = firstImageURL.components(separatedBy: ".svg")[0]
+        if url.contains("2F") {
+            let firstImageURL = url.components(separatedBy: "2F")[1]
+            if firstImageURL.contains("-3x") {
+                finalImageURL = firstImageURL.components(separatedBy: "-3x")[0]
+            } else if firstImageURL.contains(".svg") {
+                finalImageURL = firstImageURL.components(separatedBy: ".svg")[0]
+            }
         }
         switch finalImageURL {
         case "ic_profile1", "blue3": self.image = ImageLiterals.profileBlue3


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #242 

## 👩‍💻 Contents & Screenshot
안드로이드와 iOS 기기에서 저장한 이미지 주소가 달라 이미지 캐싱 과정에서 런타임 에러가 발생했습니다.
그동안은 iOS 기기들로만 테스트를 해왔기 때문에 발견하지 못한 문제인데요.
안드 기기와 함께 사용하는 앱이기 때문에 앱 심사를 올리기 전에 급하게 수정했습니다.

안드 이미지 주소는 
`2Forange1-3x.png?`

iOS 이미지 주소는
`2Fic_profile3.svg?`

와 같은 형식으로 구성되어 있습니다.

공통적으로 가지고 있는 문자열인, **2F**를 기준으로 뒷 부분만 잘라낸 후
.svg가 있으면 .svg기준으로 (orange1 등 이미지 색으로 네이밍 된 경우)
-3x가 있으면 -3x 기준으로 (profile1 등 숫자를 기준으로 네이밍 된 경우)
앞 부분을 추출합니다.

위에서 찾아본 조건에 해당되는 이미지 주소가 없다면,
default 이미지로 지정되도록 하였습니다.

이로써 이미지 캐싱과 로드 과정에서 런타임 에러가 발생하여 앱이 폭발하는 일은 없습니다!


## 📌 Review Point
백엔드 분에게 이미지 주소가 변경될 가능성이 있냐고 여쭤봤을 때 없다고 해주셨지만,
추후 이미지 주소가 변경된다면 위와 같은 문제가 발생할 가능성은 충분히 있습니당..

이미지 주소로 프로필 이미지를 판별하는 건, 서버에 의존적이라서 이 문제에 대해 다시 고민해보는 게 좋을 것 같습니다.