### PR TITLE
[FIX] 건너뛰기 할 경우 Home 화면이 두 번 navigate 되는 이슈

### DIFF
--- a/fairer-iOS/fairer-iOS/Screens/Group/HouseInviteCode/ViewController/HouseInviteCodeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/HouseInviteCode/ViewController/HouseInviteCodeViewController.swift
@@ -98,7 +98,6 @@ final class HouseInviteCodeViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        setButtonAction()
         getinviteCodeExpirationDateTime()
     }
     


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #247 

## 👩‍💻 Contents & Screenshot
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- 버튼 설정 메서드가 viewWillAppear와 viewDidLoad에 두번 설정되어 있었습니다.

## 📌 Review Point
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->

## 🧐 Question
<!-- PR 과정에서 생긴 질문을 적어주세요. -->


