### PR TITLE
[FIX] 잘못된 초대코드 입력 핸들링

### DIFF
--- a/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
+++ b/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
@@ -94,7 +94,7 @@ enum TextLiteral {
     static let enterHouseViewControllerPrimaryLabel: String = "초대코드를 입력해주세요."
     static let enterHouseViewControllerSecondaryLabel: String = "초대코드를 입력 후 바로 공간에 참여할 수 있어요!"
     static let enterHouseViewControllerTextfieldPlaceHolder: String = "12글자 입력"
-    static let enterHouseViewControllerToastWrongCode: String = "잘못된 코드입니다."
+    static let enterHouseViewControllerToastWrongCode: String = "해당하는 팀이 존재하지 않습니다"
     static let enterHouseViewControllerToastHouseFull: String = "하우스가 꽉 차서 참여할 수 없어요.\n6명까지만 참여할 수 있어요."
     
     // MARK: - HouseInfoViewController

--- a/fairer-iOS/fairer-iOS/Network/API/TeamsAPI.swift
+++ b/fairer-iOS/fairer-iOS/Network/API/TeamsAPI.swift
@@ -77,7 +77,7 @@ final class TeamsAPI {
                 let networkResult = self.judgeStatus(by: statusCode, data, response: httpUrlResponse, responseData: .postJoinTeam)
                 completion(networkResult)
             case .failure(let err):
-                print(err)
+                completion(.requestErr(err))
             }
         }
     }

--- a/fairer-iOS/fairer-iOS/Screens/Group/EnterHouse/EnterHouseViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/EnterHouse/EnterHouseViewController.swift
@@ -156,10 +156,9 @@ extension EnterHouseViewController {
             switch result {
             case .success:
                 UserDefaultHandler.hasTeam = true
-                    self?.navigationController?.pushViewController(HouseInfoViewController(), animated: true)
-            case .requestErr(let error):
-                guard let errorResponse = error as? UserErrorResponse else { return }
-                self?.showToast(errorResponse.errorMessage)
+                self?.navigationController?.pushViewController(HouseInfoViewController(), animated: true)
+            case .requestErr(_):
+                self?.showToast(TextLiteral.enterHouseViewControllerToastWrongCode)
             default:
                 print("server Error")
             }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #246 

## 👩‍💻 Contents & Screenshot
<!-- 작업 내용과 이미지를 첨부해주세요. -->
<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/d1c2fab5-a24c-43e6-a652-be2fbd3adafe" width=200px />

잘못된 초대코드를 입력할 경우 toast가 뜨며 화면이 넘어가지 않습니다.

## 📌 Review Point
```swift
case .requestErr(let error):
    guard let errorResponse = error as? UserErrorResponse else { return }
    self?.showToast(errorResponse.errorMessage)
```
기존에 작성된 코드는 언뜻 보기에는 문제가 없어 보입니다.
하지만 실제로 400 error가 뜨면 result 자체가 들어오지 않아 case 문에서 분기가 처리되지 않습니다.

TeamsAPI의 function에서 먼저 failure가 잡히는데 이때 success 결과만 EnterHouseVC에 넘어오기 때문인데요.
TeamsAPI에서 failure 결과에 대한 completion handler 를 추가하여 VC에 넘겨주었더니 잘 동작합니다.

원래 작성해주신대로 error 결과 구조체의 errorMessage를 toast 문구로 사용하려고 했으나 
completion handler 로 전달되는 request error result값은 기존과는 다른 형태라서
TextLiteral에 메시지를 직접 작성해서 추가해두었습니다!
