### PR TITLE
[CHORE] v1.0.0 (build 7) 릴리즈에 따른 develop 브랜치 업데이트

### DIFF
--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -1630,7 +1630,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 7PQ6FMV22H;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1668,7 +1668,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 7PQ6FMV22H;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
+++ b/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
@@ -28,7 +28,7 @@ enum TextLiteral {
     
     // MARK: - OnboardingNameViewController
     
-    static let onboardingNameViewControllerNameLabel: String = "이름을 입력해주세요."
+    static let onboardingNameViewControllerNameLabel: String = "닉네임을 입력해주세요."
     static let onboardingNameViewControllerTextFieldPlaceholder: String = "예) 홍길동"
     
     // MARK: - OnboardingProfileViewController
@@ -222,7 +222,7 @@ enum TextLiteral {
     // MARK: - SettingProfileViewController
     
     static let settingProfileViewControllerTitleLabel = "프로필을 설정해주세요."
-    static let settingProfileViewControllerProfileNameLabel = "이름"
+    static let settingProfileViewControllerProfileNameLabel = "닉네임"
     static let settingProfileViewControllerProfileStatusLabel = "상태 메세지"
     static let settingProfileViewControllerPlaceholderText = "Text"
     

--- a/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/Login/LoginViewController.swift
@@ -150,14 +150,16 @@ final class LoginViewController: BaseViewController {
                 }
                 UserDefaultHandler.isLogin = true
                 
-                guard let isNewMember = data.isNewMember, let hasTeam = data.hasTeam, let userName = data.memberName else { return }
+                guard let isNewMember = data.isNewMember, let hasTeam = data.hasTeam else { return }
                 
                 if !isNewMember && hasTeam {
                     UserDefaultHandler.hasTeam = true
                     RootHandler.shared.change(root: .Home)
                 } else if !isNewMember && !hasTeam {
                     let groupMainViewController = GroupMainViewController()
-                    groupMainViewController.setUserName(name: userName)
+                    if let userName = data.memberName {
+                        groupMainViewController.setUserName(name: userName)
+                    }
                     RootHandler.shared.change(root: .groupMain)
                 } else if isNewMember && !hasTeam  {
                     let onBoardingNameViewController = OnboardingNameViewController()

--- a/fairer-iOS/fairer-iOS/Screens/Group/HouseInviteCode/View/InviteCodeButtonView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/HouseInviteCode/View/InviteCodeButtonView.swift
@@ -50,6 +50,7 @@ final class InviteCodeButtonView: UIView {
         let button = UIButton(configuration: config)
         button.layer.cornerRadius = 8
         button.backgroundColor = UIColor(red: 0.992, green: 0.945, blue: 0.38, alpha: 1)
+        button.isHidden = true
         return button
     }()
     let skipButton: UIButton = {

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/HomeView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/HomeView.swift
@@ -90,9 +90,8 @@ final class HomeView: BaseUIView {
                          emptyHouseWorkImage)
         
         toolBarView.snp.makeConstraints {
-            $0.leading.trailing.equalTo(self.safeAreaLayoutGuide)
-            $0.bottom.equalToSuperview()
-            $0.height.equalTo(110)
+            $0.leading.trailing.bottom.equalTo(self.safeAreaLayoutGuide)
+            $0.height.equalTo(76)
         }
         
         titleLabelStackView.addArrangedSubview(nameTitleLabel)
@@ -143,11 +142,11 @@ final class HomeView: BaseUIView {
         homeWeekCalendarCollectionView.snp.makeConstraints {
             $0.top.equalTo(homeCalenderView.snp.bottom)
             $0.leading.trailing.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
-            $0.height.equalTo(95)
+            $0.height.equalTo(68)
         }
         
         calendarDailyTableView.snp.makeConstraints {
-            $0.top.equalTo(homeWeekCalendarCollectionView.snp.bottom).offset(-15)
+            $0.top.equalTo(homeWeekCalendarCollectionView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(toolBarView.snp.top)
         }
@@ -157,10 +156,10 @@ final class HomeView: BaseUIView {
         }
         
         emptyHouseWorkImage.snp.makeConstraints {
-            $0.top.equalTo(homeWeekCalendarCollectionView.snp.bottom)
+            $0.top.equalTo(homeWeekCalendarCollectionView.snp.bottom).offset(10)
+            $0.bottom.equalTo(toolBarView.snp.top).offset(-10)
             $0.centerX.equalToSuperview()
-            $0.width.equalTo(156)
-            $0.height.equalTo(240)
+            $0.width.equalTo(emptyHouseWorkImage.snp.height).multipliedBy(0.65)
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/ToolBar/HomeViewControllerToolBar.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/ToolBar/HomeViewControllerToolBar.swift
@@ -13,15 +13,12 @@ final class HomeViewControllerToolBar: UIView {
     
     // MARK: - property
     
-    private let contentView: UIView = {
+    private let contentView = UIView()
+    private let borderView: UIView = {
         let view = UIView()
-        view.backgroundColor = .clear
-        view.layer.borderWidth = 0.7
-        let borderColor = UIColor.gray300.withAlphaComponent(0.2)
-        view.layer.borderColor = borderColor.cgColor
+        view.backgroundColor = .gray300.withAlphaComponent(0.2)
         return view
     }()
-    
     private let affairView: UIView = {
         let view = UIView()
         view.layer.borderColor = UIColor.gray200.cgColor
@@ -52,11 +49,16 @@ final class HomeViewControllerToolBar: UIView {
     
     private func render() {
         self.addSubview(contentView)
-        contentView.addSubview(affairView)
-        affairView.addSubviews(affairLabel,plusImage)
+        contentView.addSubviews(borderView, affairView)
+        affairView.addSubviews(affairLabel, plusImage)
         
         contentView.snp.makeConstraints {
             $0.edges.equalToSuperview()
+        }
+        
+        borderView.snp.makeConstraints {
+            $0.width.top.equalToSuperview()
+            $0.height.equalTo(0.7)
         }
         
         affairView.snp.makeConstraints {

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/WeekCalendarView/HomeWeekCalendarCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/WeekCalendarView/HomeWeekCalendarCollectionView.swift
@@ -40,8 +40,8 @@ final class HomeWeekCalendarCollectionView: BaseUIView {
     var yearMonthDateByTouchedCell: ((String)->())?
     private enum Size {
         static let collectionSpacing: CGFloat = 0
-        static let cellWidth: CGFloat = 40
-        static let cellHeight: CGFloat = 56
+        static let cellWidth: CGFloat = UIScreen.main.bounds.width * 0.10
+        static let cellHeight: CGFloat = 68
         static let collectionInsets = UIEdgeInsets(
             top: collectionSpacing,
             left: collectionSpacing,
@@ -53,10 +53,9 @@ final class HomeWeekCalendarCollectionView: BaseUIView {
     
     private let collectionViewFlowLayout: UICollectionViewFlowLayout = {
         let flowLayout = UICollectionViewFlowLayout()
-        flowLayout.scrollDirection = .horizontal
+        flowLayout.scrollDirection = .vertical
         flowLayout.sectionInset = Size.collectionInsets
         flowLayout.itemSize = CGSize(width: Size.cellWidth, height: Size.cellHeight)
-        flowLayout.minimumLineSpacing = 8
         return flowLayout
     }()
     lazy var collectionView: UICollectionView = {

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/WeekCalendarView/HomeWeekCalendarCollectionViewCell.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/WeekCalendarView/HomeWeekCalendarCollectionViewCell.swift
@@ -80,26 +80,26 @@ final class HomeWeekCalendarCollectionViewCell: BaseCollectionViewCell {
         self.bringSubviewToFront(workDot)
         self.bringSubviewToFront(workBlueBadge)
         
+        globalView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(60)
+            $0.bottom.equalToSuperview()
+        }
+        
         workDot.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.width.height.equalTo(16)
-            $0.bottom.equalTo(globalView.snp.top).offset(3)
+            $0.top.equalToSuperview()
         }
         
         workBlueBadge.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.width.height.equalTo(16)
-            $0.bottom.equalTo(globalView.snp.top).offset(3)
+            $0.top.equalToSuperview()
         }
         
         workLeftLabel.snp.makeConstraints {
             $0.center.equalToSuperview()
-        }
-        
-        globalView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(60)
-            $0.bottom.equalToSuperview()
         }
         
         dayLabel.snp.makeConstraints {

--- a/fairer-iOS/fairer-iOS/Screens/Home/SettingHomeRule/ViewController/View/SettingHomeRuleHeaderView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/SettingHomeRule/ViewController/View/SettingHomeRuleHeaderView.swift
@@ -30,7 +30,7 @@ final class SettingHomeRuleHeaderView: UITableViewHeaderFooterView {
     var settingHomeRuleTextField = TextField(type: .medium, placeHolder: TextLiteral.settingHomeRuleTextFieldPlaceholder)
     private let settingHomeRuleTextFieldeWarningLabel: UILabel = {
         let label = UILabel()
-        label.setTextWithLineHeight(text: "텍스트는 16글자를 초과하여 입력하실 수 없어요.", lineHeight: 22)
+        label.setTextWithLineHeight(text: TextLiteral.textFieldWarningOverSixteen, lineHeight: 22)
         label.textColor = .negative20
         label.font = .body2
         return label
@@ -67,7 +67,7 @@ final class SettingHomeRuleHeaderView: UITableViewHeaderFooterView {
         addSubviews(settingHomeRulePrimaryLabel, settingHomeRuleTextFieldLabel, settingHomeRuleTextField, settingHomeRuleTextFieldeWarningLabel, settingHomeRuleInfoLabel, titleLabel)
         
         settingHomeRulePrimaryLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(40)
+            $0.top.equalToSuperview()
             $0.leading.equalToSuperview().inset(SizeLiteral.leadingTrailingPadding)
         }
         

--- a/fairer-iOS/fairer-iOS/Screens/Setting/SettingMain/ViewController/SettingViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Setting/SettingMain/ViewController/SettingViewController.swift
@@ -178,8 +178,8 @@ final class SettingViewController: BaseViewController {
     }
     
     private func postLogout() {
-        if let bundleID = Bundle.main.bundleIdentifier {
-            UserDefaults.standard.removePersistentDomain(forName: bundleID)
+        for key in UserDefaults.standard.dictionaryRepresentation().keys {
+            UserDefaults.standard.removeObject(forKey: key.description)
         }
         RootHandler.shared.change(root: .login)
     }


### PR DESCRIPTION
## 👩‍💻 Contents & Screenshot
release를 준비하는 과정, 그리고 리젝 사유를 해결하는 과정에서 바뀐 코드들이 많아서
아래에 자세하게 설명을 추가해두었습니다.

궁금한 사항 있으시다면 언제든지 댓글 남겨주시고,
저 나름대로 꼼꼼하게 검수하면서 반영했으나
develop과 main에 머지될 사항이니 꼼꼼하게 확인 부탁드립니다.

[1] Build version 변경: 2 -> 7

[2] 사용자 이름 입력 라이팅 변경: 이름 > 닉네임

[3] 로그인 후 화면이 넘어가지 않는 이슈 해결 (LoginVC)

[4] 카카오톡 공유하기 버튼 임시로 hidden 처리

[5] 집안일 추가하기 버튼 height 줄이기: 인디케이터가 없는 버젼을 가지고 있는 기기의 경우 (일부 아이폰과 아이패드) 집안일 추가하기 버튼의 backgroundView가 너무 커서 필요 이상의 영역을 차지하여 height를 줄였습니다.
height를 줄인 후 기존에 그림자 역할을 하던 뷰 역시 작아져서 safe area를 기준으로 선이 생겼었는데요. 그걸 해결하기 위해 집안일 버튼 추가하기 영역의 상단에 view를 추가하여 윗부분에만 그림자가 있는 것처럼 처리하였습니다.
|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/a0959a1a-ac6e-4a64-9e5e-6a15050b45f8" width=200px />|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/e6ca1fd9-93ed-4189-9944-8f94d86aedd2" width=200px />|
|:---:|:---:|
|<center>줄이기 전</center>|<center>줄이기 후</center>|

[6] 주간 캘린더 크기와 영역 다시 잡기, 한쪽으로 쏠린 cell들 collectionView width에 딱 맞게 맞추기
(변경된 사항을 잘 보여주기 위해 주간 캘린더 collectionview에 border를 넣었습니다)
|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/5bb801d5-de2e-4848-8c6d-c8fa2e1f6d9d" width=200px />|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/376137bb-17c7-4bab-ad5f-4d0e7b6fcd24" width=200px />|
|:---:|:---:|
|<center>조정 전</center>|<center>조정 후</center>|

[7] 하우스 규칙 라벨 top padding 조정
|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/020a261f-7b9f-4ea2-8460-7a17f86d7e99" width=200px />|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/236d97d5-00b8-4b60-a2d7-075ca1f81278" width=200px />|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/23544832-47e2-4f32-8655-4bef0ab2afcc" width=200px />|
|:---:|:---:|:---:|
|<center>수정 전</center>|<center>수정 후</center>|<center>피그마</center>|

[8] 집안일 empty view의 크기와 영역 조정
높이는 (주간 캘린더의 bottom - 집안일 추가하기 버튼 view의 top) - 약간의 패딩으로 지정했습니다.
너비는 높이의 0.65배로 지정하여 원래 이미지가 눌리지 않도록 처리했습니다.
<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/ed59d7cf-4058-4ace-8921-4cb54db58fa4" width=500px />

[9] UserDefault 전부 초기화 로직 변경: bundleID > for문 돌며 모든 userdefault값 삭제하기


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- [UICollectionView의 Spacing](https://velog.io/@leeinae/UICollectionView-Spacing%EC%9D%B4-%ED%97%B7%EA%B0%88%EB%A6%AC%EB%8A%94-%EC%82%AC%EA%B1%B4%EC%97%90-%EB%8C%80%ED%95%98%EC%97%AC)
- ChatGPT