### PR TITLE
[CHORE] api/data binding 속도 개선하기

### DIFF
--- a/fairer-iOS/fairer-iOS/Screens/Group/GroupMain/GroupMainViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/GroupMain/GroupMainViewController.swift
@@ -80,10 +80,14 @@ final class GroupMainViewController: BaseViewController {
     
     // MARK: - life cycle
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        getMyInfoFromServer()
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setButtonAction()
-        getMyInfoFromServer()
     }
 
     override func render() {

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -114,6 +114,7 @@ final class HomeViewController: BaseViewController {
                 endDate: homewView.homeWeekCalendarCollectionView.datePickedByOthers
             )
         }
+        self.getHouseWorksByWeek(isOwn: self.checkMemeberCellIsOwn())
     }
     
     override func configUI() {
@@ -414,7 +415,6 @@ private extension HomeViewController {
                         self.notFinishedWorkSum = self.workTotalNum - self.finishedWorkSum
                     }
                     self.homewView.calendarDailyTableView.reloadData()
-                    self.getHouseWorksByWeek(isOwn: isOwn)
                 }
             } else {
                 guard let selectedMemberId = self.selectedMemberId else { return }
@@ -443,9 +443,6 @@ private extension HomeViewController {
                             
                             self.notFinishedWorkSum = self.workTotalNum - self.finishedWorkSum
                         }
-                    }
-                    DispatchQueue.global().async {
-                        self.getHouseWorksByWeek(isOwn: isOwn)
                     }
                 }
             }
@@ -704,6 +701,7 @@ private extension HomeViewController {
         homewView.homeWeekCalendarCollectionView.startOfWeekDate = Date().startOfWeek
         homewView.homeWeekCalendarCollectionView.datePickedByOthers = Date().dateToString
         homewView.homeWeekCalendarCollectionView.fullDateList = homewView.homeWeekCalendarCollectionView.getThisWeekInDate()
+        self.getHouseWorksByWeek(isOwn: self.checkMemeberCellIsOwn())
         self.getHouseWorksByDate(
             isOwn: self.checkMemeberCellIsOwn(),
             startDate: homewView.homeWeekCalendarCollectionView.datePickedByOthers,
@@ -757,6 +755,7 @@ private extension HomeViewController {
                 startDate: pickedDate.dateToString,
                 endDate: pickedDate.dateToString
             )
+            self.getHouseWorksByWeek(isOwn: self.checkMemeberCellIsOwn())
             self.setupNavigationBar()
         }
         homewView.datePickerView.changeClosure = { [weak self] val in
@@ -820,6 +819,7 @@ private extension HomeViewController {
             startDate: homewView.homeWeekCalendarCollectionView.fullDateList.first ?? String(),
             endDate: homewView.homeWeekCalendarCollectionView.fullDateList.first ?? String()
         )
+        self.getHouseWorksByWeek(isOwn: checkMemeberCellIsOwn())
     }
 }
 

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/EditHouseWork/ViewController/EditHouseWorkViewController.swift
@@ -179,9 +179,15 @@ final class EditHouseWorkViewController: BaseViewController {
     
     required init?(coder: NSCoder) { nil }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        getHouseWorkById()
+        getMyInfo()
+        getTeamInfo()
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        getHouseWorkById()
         setDeleteButton()
         setDatePicker()
         setupNotificationCenter()
@@ -189,8 +195,6 @@ final class EditHouseWorkViewController: BaseViewController {
         didTappedRepeatCycleMenuButton()
         didSelectDaysOfWeek()
         hidekeyboardWhenTappedAround()
-        getMyInfo()
-        getTeamInfo()
         addButtonAction()
         didConfirmRepeatAlertActionType()
     }

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/SetHouseWork/ViewController/SetHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/SetHouseWork/ViewController/SetHouseWorkViewController.swift
@@ -150,17 +150,21 @@ final class SetHouseWorkViewController: BaseViewController {
     
     required init?(coder: NSCoder) { nil }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        getTeamInfo()
+        getMyInfo()
+        setInitialHouseWork()
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        setInitialHouseWork()
         setDatePicker()
         didTappedHouseWork()
         didDeleteHouseWork()
         didTappedRepeatCycleMenuButton()
         didSelectDaysOfWeek()
         setDoneButton()
-        getTeamInfo()
-        getMyInfo()
     }
     
     override func render() {

--- a/fairer-iOS/fairer-iOS/Screens/HouseWork/WriteHouseWork/ViewController/WriteHouseWorkViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/HouseWork/WriteHouseWork/ViewController/WriteHouseWorkViewController.swift
@@ -173,16 +173,20 @@ final class WriteHouseWorkViewController: BaseViewController {
     
     required init?(coder: NSCoder) { nil }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setDatePicker()
+        getMyInfo()
+        getTeamInfo()
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        setDatePicker()
         setupNotificationCenter()
         setupDelegation()
         didTappedRepeatCycleMenuButton()
         didSelectDaysOfWeek()
         hidekeyboardWhenTappedAround()
-        getMyInfo()
-        getTeamInfo()
         addButtonAction()
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/Setting/ChangeHouseName/ChangeHouseNameViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Setting/ChangeHouseName/ChangeHouseNameViewController.swift
@@ -70,11 +70,15 @@ final class ChangeHouseNameViewController: BaseViewController {
     
     // MARK: - life cycle
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        getTeamInfo()
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setupDelegation()
         setupNotificationCenter()
-        getTeamInfo()
     }
     
     override func render() {

--- a/fairer-iOS/fairer-iOS/Screens/Setting/SettingAlarm/ViewController/SettingAlarmViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Setting/SettingAlarm/ViewController/SettingAlarmViewController.swift
@@ -29,10 +29,14 @@ final class SettingAlarmViewController: BaseViewController {
     
     // MARK: - life cycle
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        getAlarmStatus()
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setButtonAction()
-        getAlarmStatus()
     }
     
     override func render() {


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #253 

## 👩‍💻 Contents & Screenshot
<!-- 작업 내용과 이미지를 첨부해주세요. -->
[api 호출 시점 변경: viewDidLoad > viewWillAppear]
- ChangeHouseNameVC, SettingAlarmVC, EditHouseWorkVC, SetHouseWorkVC, WriteHouseWorkVC, GroupMainVC

**개선 전**

https://github.com/fairer-iOS/fairer-iOS/assets/81340603/9aa1c6f7-47a5-4af6-9d74-8f9358dd71ad

**개선 후**

https://github.com/fairer-iOS/fairer-iOS/assets/81340603/72c5e121-556f-42a6-9c34-84d368e7587f

[HomeVC 코드 정리]
api 호출이 가장 많아서 로드가 느렸던 HomeVC의 코드 일부를 정리했습니다.

주간 캘린더의 특정 날짜를 터치한 후 바로 다른 날짜를 터치하면 로딩이 길어져서 날짜 셀이 selected 되지 않는 문제가 있었는데요.
주간 캘린더의 날짜 셀을 눌렀을 때 (선택한 날짜 집안일 정보 + 해당 주 집안일 정보)를 불러와서 딜레이가 있었던 겁니다!
셀을 눌렀을 때 매번 해당 주에 대한 집안일 정보를 불러오기보다는 주 정보가 업데이트 되어야 하는 시기에만 호출되도록 수정했습니다.

그래서 주간 집안일 정보는 
1) 다른 화면에 다녀왔을 때  
2) 지난주 혹은 다음주로 스와이프할 때 
3) datepicker로 날짜 변경했을 때
만 불러옵니다!

**개선 전**

https://github.com/fairer-iOS/fairer-iOS/assets/81340603/ecb21bfa-5dfc-4690-81c7-9c0f76e5525a

**개선 후**

https://github.com/fairer-iOS/fairer-iOS/assets/81340603/6898b19e-dff1-4866-b610-59f59f6e04d8

나중에 날 잡고 HomeVC 코드 싹 정리해볼게요!