### PR TITLE
[FEAT] 카카오톡 공유하기 구현

### DIFF
--- a/fairer-iOS/fairer-iOS/Global/Supports/Info.plist
+++ b/fairer-iOS/fairer-iOS/Global/Supports/Info.plist
@@ -21,7 +21,7 @@
 			<string></string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>kakaod16a9978adb770f94c7ba98df76bd292</string>
+				<string>kakao</string>
 			</array>
 		</dict>
 	</array>

--- a/fairer-iOS/fairer-iOS/Global/Supports/Info.plist
+++ b/fairer-iOS/fairer-iOS/Global/Supports/Info.plist
@@ -7,6 +7,8 @@
 		<dict>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string></string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>1.</string>
@@ -15,6 +17,8 @@
 		<dict>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string></string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>kakao</string>

--- a/fairer-iOS/fairer-iOS/Global/Supports/Info.plist
+++ b/fairer-iOS/fairer-iOS/Global/Supports/Info.plist
@@ -21,7 +21,7 @@
 			<string></string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>kakao</string>
+				<string>kakaod16a9978adb770f94c7ba98df76bd292</string>
 			</array>
 		</dict>
 	</array>

--- a/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
+++ b/fairer-iOS/fairer-iOS/Global/Supports/SceneDelegate.swift
@@ -34,6 +34,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         if let url = URLContexts.first?.url {
             GIDSignIn.sharedInstance.handle(url)
+            UserDefaultHandler.hasTeam ? navigateToAlreadyInGroup() : navigateToEnterHouse(url)
         }
     }
 
@@ -97,5 +98,28 @@ extension SceneDelegate {
                 self?.errorWindow = window
             }
         }
+    }
+    
+    private func navigateToEnterHouse(_ url: URL) {
+        if url.absoluteString.contains("example.com") {
+            guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else { return }
+            let enterHouseViewController = EnterHouseViewController()
+            sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: enterHouseViewController)
+            
+            let inviteCode = url.absoluteString.components(separatedBy: "example.com/")[1].components(separatedBy: "/?link")[0]
+            enterHouseViewController.enterHouseCodeTextfield.text = inviteCode
+            enterHouseViewController.enterHouseDoneButton.isDisabled = false
+            
+            enterHouseViewController.backButton.isHidden = true
+            enterHouseViewController.navigationItem.hidesBackButton = true
+            enterHouseViewController.navigationController?.setViewControllers([enterHouseViewController], animated: true)
+        }
+    }
+    
+    private func navigateToAlreadyInGroup() {
+        guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else { return }
+        let alreadyInGroupViewController = AlreadyInGroupViewController()
+        sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: alreadyInGroupViewController)
+        alreadyInGroupViewController.navigationController?.setViewControllers([alreadyInGroupViewController], animated: true)
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/Auth/OnboardingProfile/ViewController/OnboardingProfileViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Auth/OnboardingProfile/ViewController/OnboardingProfileViewController.swift
@@ -102,6 +102,7 @@ class OnboardingProfileViewController: BaseViewController {
         if let name = userName {
             groupMainViewController.setUserName(name: name)
         }
+        groupMainViewController.navigationItem.hidesBackButton = true
         self.navigationController?.pushViewController(groupMainViewController, animated: true)
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/Group/AlreadyInGroup/AlreadyInGroupViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/AlreadyInGroup/AlreadyInGroupViewController.swift
@@ -44,6 +44,11 @@ final class AlreadyInGroupViewController: BaseViewController {
     
     // MARK: - life cycle
     
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setButtonAction()
+    }
+    
     override func render() {
         view.addSubview(alreadyInGroupTitleLabel)
         alreadyInGroupTitleLabel.snp.makeConstraints {
@@ -71,4 +76,17 @@ final class AlreadyInGroupViewController: BaseViewController {
         }
     }
     
+    // MARK: - func
+    
+    private func setButtonAction() {
+        let backToMainAction = UIAction { [weak self] _ in
+            self?.navigateToHome()
+        }
+        
+        self.backToMainButton.addAction(backToMainAction, for: .touchUpInside)
+    }
+    
+    private func navigateToHome() {
+        RootHandler.shared.change(root: .Home)
+    }
 }

--- a/fairer-iOS/fairer-iOS/Screens/Group/EnterHouse/EnterHouseViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/EnterHouse/EnterHouseViewController.swift
@@ -13,7 +13,7 @@ final class EnterHouseViewController: BaseViewController {
 
     // MARK: - property
     
-    private let backButton = BackButton()
+    let backButton = BackButton()
     private let enterHousePrimaryLabel: UILabel = {
         let label = UILabel()
         label.setTextWithLineHeight(text: TextLiteral.enterHouseViewControllerPrimaryLabel, lineHeight: 28)
@@ -28,8 +28,8 @@ final class EnterHouseViewController: BaseViewController {
         label.textColor = .gray400
         return label
     }()
-    private let enterHouseCodeTextfield = TextField(type: .large, placeHolder: TextLiteral.enterHouseViewControllerTextfieldPlaceHolder)
-    private lazy var enterHouseDoneButton: MainButton = {
+    let enterHouseCodeTextfield = TextField(type: .large, placeHolder: TextLiteral.enterHouseViewControllerTextfieldPlaceHolder)
+    lazy var enterHouseDoneButton: MainButton = {
         let button = MainButton()
         button.isDisabled = true
         button.title = TextLiteral.doneButtonText

--- a/fairer-iOS/fairer-iOS/Screens/Group/HouseInviteCode/View/InviteCodeButtonView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Group/HouseInviteCode/View/InviteCodeButtonView.swift
@@ -50,7 +50,6 @@ final class InviteCodeButtonView: UIView {
         let button = UIButton(configuration: config)
         button.layer.cornerRadius = 8
         button.backgroundColor = UIColor(red: 0.992, green: 0.945, blue: 0.38, alpha: 1)
-        button.isHidden = true
         return button
     }()
     let skipButton: UIButton = {


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #256 

## 👩‍💻 Contents & Screenshot
<!-- 작업 내용과 이미지를 첨부해주세요. -->

|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/14d1d1c4-5362-4a06-804e-443ac37bb4ff" width=200px />|<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/183b10b8-31ae-46af-a535-4ae580ba274f" width=200px />|
|:---:|:---:|

카카오톡으로 초대카드를 공유하는 프로세스는 준혁님(천재 막둥이)께서 구현해주셨는데요.
저는 유저가 카카오톡에서 초대 받기를 눌렀을 때 이후의 프로세스를 구현했습니다.

먼저 초대를 받은 유저는 크게 3 가지 상태 중 하나에 놓여 있을 겁니다.
### 첫째, 앱이 설치되지 않은 경우
이 같은 경우에는 페어러를 다운 받을 수 있도록 앱스토어 모달을 띄웠습니다.

<img src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/844966a3-d8c1-48cd-bd43-c7f19173846d" width=200px />

준혁님께서 구현하실 시기에는 앱이 출시가 안돼서 kakao developers에서 web link를 넣으셨는데,
안드에서도 동일하게 web link를 사용하고 있어서 플레이 스토어로 넘어가는 이슈가 있었죠..

이 이슈는 앱이 출시됨에 따라 해결됐습니다. 
<img width="600" alt="스크린샷 2023-08-17 오후 3 58 27" src="https://github.com/fairer-iOS/fairer-iOS/assets/81340603/130b18a9-7757-4f9c-8ee1-2f40191bb7c7">
앱스토어 ID (Apple ID)를 넣으면 자동으로 앱스토어로 링크 됩니다!

### 둘째, 앱이 설치되어 있고 팀도 있는 경우

https://github.com/fairer-iOS/fairer-iOS/assets/81340603/8e7b4684-5a06-4ed5-aaec-2a5668d2306b

hasTeam을 검사해서 팀이 있는 경우 AlreadyInGroupVC로 이동합니다!

### 셋째, 앱이 설치되어 있지만 팀에 합류하지 않은 경우

https://github.com/fairer-iOS/fairer-iOS/assets/81340603/141ef5b8-7e6c-4ac7-ba28-e841fe04ecce

초대코드 입력 화면으로 이동합니다.
초대코드는 자동으로 작성되어 있고 하단의 메인 버튼은 활성화 됩니다.

#### 어떻게 구현했을까 ?
iOS 에서는 (외부) > (앱의 특정 view)로 이동시키기 위해 Universal Link라는 걸 만들어 사용합니다.
하지만 universal link는 SSL(https)가 있는 서버가 필요합니다..! (우린 http..ㅎㅎ)
firebase에서 제공하는 dynamic link라는 서비스를 사용하려고 시도했으나 2025년 서비스가 중단된다는 이슈가 있었습니다,,

여기서 꼼수를 좀 썼는데요.
먼저, 준혁님께서 전에 동적링크를 만드는 함수를 읽어봅시다.
아래 함수는 페어러에서 카카오톡 공유하기 버튼을 누르면 동작합니다.
파라미터로 inviteCode가 전달되어 link의 일부가 초대코드로 구성됩니다!
이 link는 카카오톡 초대카드에 담겨 전달되는데..

``` swift
private func createDynamicLink(
        inviteCode: String
    ) -> URL {
        guard let webLink = URL(string: "https://www.apple.com/kr/app-store/") else {
            return URL(fileURLWithPath: "")
        }
        let dynamicLinksDomainURIPrefix = "https://example.com/\(inviteCode)" // 초대코드를 넣어 링크를 구성합니다!!!!!!
        let bundleID = "com.ios.fairer"
        
        guard let linkBuilder = DynamicLinkComponents(link: webLink, domainURIPrefix: dynamicLinksDomainURIPrefix) else {
            return URL(fileURLWithPath: "")
        }
        linkBuilder.iOSParameters = DynamicLinkIOSParameters(bundleID: bundleID)
        
        guard let longDynamicLink = linkBuilder.url else {
            return URL(fileURLWithPath: "")
        }
        return longDynamicLink
    }
```
카톡으로 초대를 받은 유저가 초대받기 버튼을 누르면 scenedelegate의 openURLContexts에서 전달 받은 url을 확인할 수 있어요!

서버와 연결되지 않은 동적 링크라서 콘솔 창에는 socket 이 연결되지 않았다는 에러가 뜨지만,,
우리에게는 초대코드가 있으니 굳이 서버와 연결하지 않아도,, 분기처리를 할 수 있습니다 ㅎㅎ 

hasTeam이 false인 경우 url를 쪼개서 inviteCode를 꺼내 EnterHouseVC로 navigate하는 방법으로 3번 케이스를 구현했습니다..!

## 📌 Review Point
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
카톡방에 보낸 kakao client key를 먼저 입력해주세요.
애플 계정으로 팀을 하나 만들고 카카오톡으로 공유하여 초대받기를 눌러보세요 (url이 제대로 생성되려면 페어러에서 띄운 카카오톡 창에서 바로 초대 받지 말고 홈 화면 한 번 갔다가 카톡 접속 부탁드려요!)
다음으로 팀이 없는 구글 계정으로 로그인 한 후 초대 받기를 눌러보세요!
 

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[URLSchemes와 Universal Link]
https://dev-dain.tistory.com/270
