### PR TITLE
[ADD] 피드백 추가/수정 뷰 + 재촉하기 뷰 구현

### DIFF
--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		52B6BD0D2A9F501000022A20 /* EmojiCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B6BD0C2A9F501000022A20 /* EmojiCollectionView.swift */; };
 		52B6BD0F2A9F501F00022A20 /* EmojiCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B6BD0E2A9F501F00022A20 /* EmojiCollectionViewCell.swift */; };
 		52B6BD112A9FA2D100022A20 /* AddFeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B6BD102A9FA2D100022A20 /* AddFeedbackView.swift */; };
+		52B6BD132A9FACE000022A20 /* EditFeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B6BD122A9FACE000022A20 /* EditFeedbackView.swift */; };
 		52C09CED29113D3500B46F15 /* HouseMemberCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C09CEC29113D3500B46F15 /* HouseMemberCollectionView.swift */; };
 		52C09CEF29113D3800B46F15 /* HouseMemberCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C09CEE29113D3700B46F15 /* HouseMemberCollectionViewCell.swift */; };
 		52C09CF329115FC300B46F15 /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C09CF229115FC300B46F15 /* SettingViewController.swift */; };
@@ -260,6 +261,7 @@
 		52B6BD0C2A9F501000022A20 /* EmojiCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCollectionView.swift; sourceTree = "<group>"; };
 		52B6BD0E2A9F501F00022A20 /* EmojiCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCollectionViewCell.swift; sourceTree = "<group>"; };
 		52B6BD102A9FA2D100022A20 /* AddFeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFeedbackView.swift; sourceTree = "<group>"; };
+		52B6BD122A9FACE000022A20 /* EditFeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditFeedbackView.swift; sourceTree = "<group>"; };
 		52C09CEC29113D3500B46F15 /* HouseMemberCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HouseMemberCollectionView.swift; sourceTree = "<group>"; };
 		52C09CEE29113D3700B46F15 /* HouseMemberCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HouseMemberCollectionViewCell.swift; sourceTree = "<group>"; };
 		52C09CF229115FC300B46F15 /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
@@ -780,6 +782,7 @@
 			children = (
 				52B6BD0B2A9F4FF300022A20 /* EmojiView */,
 				52B6BD102A9FA2D100022A20 /* AddFeedbackView.swift */,
+				52B6BD122A9FACE000022A20 /* EditFeedbackView.swift */,
 			);
 			path = FeedbackView;
 			sourceTree = "<group>";
@@ -1425,6 +1428,7 @@
 				5ACADCCC2A5559DA00B92C07 /* FCMTokenResponse.swift in Sources */,
 				914C69CC29AA0D17008EA9EE /* BaseURLConstant.swift in Sources */,
 				52D075662A53110300B5C692 /* AlarmRequest.swift in Sources */,
+				52B6BD132A9FACE000022A20 /* EditFeedbackView.swift in Sources */,
 				914C69CE29AA2F03008EA9EE /* ErrorResponse.swift in Sources */,
 				5205054728D8626B00355055 /* OnboardingProfileGroupCollectionViewCell.swift in Sources */,
 				52E4C083297CE586002AC755 /* MemberCollectionViewCell.swift in Sources */,

--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		52A7204A29E27DAD005E29C6 /* RepeatAlertTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A7204929E27DAD005E29C6 /* RepeatAlertTableViewCell.swift */; };
 		52B6BD0D2A9F501000022A20 /* EmojiCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B6BD0C2A9F501000022A20 /* EmojiCollectionView.swift */; };
 		52B6BD0F2A9F501F00022A20 /* EmojiCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B6BD0E2A9F501F00022A20 /* EmojiCollectionViewCell.swift */; };
+		52B6BD112A9FA2D100022A20 /* AddFeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B6BD102A9FA2D100022A20 /* AddFeedbackView.swift */; };
 		52C09CED29113D3500B46F15 /* HouseMemberCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C09CEC29113D3500B46F15 /* HouseMemberCollectionView.swift */; };
 		52C09CEF29113D3800B46F15 /* HouseMemberCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C09CEE29113D3700B46F15 /* HouseMemberCollectionViewCell.swift */; };
 		52C09CF329115FC300B46F15 /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C09CF229115FC300B46F15 /* SettingViewController.swift */; };
@@ -258,6 +259,7 @@
 		52A7204929E27DAD005E29C6 /* RepeatAlertTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatAlertTableViewCell.swift; sourceTree = "<group>"; };
 		52B6BD0C2A9F501000022A20 /* EmojiCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCollectionView.swift; sourceTree = "<group>"; };
 		52B6BD0E2A9F501F00022A20 /* EmojiCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCollectionViewCell.swift; sourceTree = "<group>"; };
+		52B6BD102A9FA2D100022A20 /* AddFeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFeedbackView.swift; sourceTree = "<group>"; };
 		52C09CEC29113D3500B46F15 /* HouseMemberCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HouseMemberCollectionView.swift; sourceTree = "<group>"; };
 		52C09CEE29113D3700B46F15 /* HouseMemberCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HouseMemberCollectionViewCell.swift; sourceTree = "<group>"; };
 		52C09CF229115FC300B46F15 /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
@@ -777,32 +779,9 @@
 			isa = PBXGroup;
 			children = (
 				52B6BD0B2A9F4FF300022A20 /* EmojiView */,
-				52B6BD0A2A9F4FC700022A20 /* HurryView */,
-				52B6BD092A9F4FC000022A20 /* EditFeedbackView */,
-				52B6BD082A9F4FB300022A20 /* AddFeedbackView */,
+				52B6BD102A9FA2D100022A20 /* AddFeedbackView.swift */,
 			);
 			path = FeedbackView;
-			sourceTree = "<group>";
-		};
-		52B6BD082A9F4FB300022A20 /* AddFeedbackView */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = AddFeedbackView;
-			sourceTree = "<group>";
-		};
-		52B6BD092A9F4FC000022A20 /* EditFeedbackView */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = EditFeedbackView;
-			sourceTree = "<group>";
-		};
-		52B6BD0A2A9F4FC700022A20 /* HurryView */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = HurryView;
 			sourceTree = "<group>";
 		};
 		52B6BD0B2A9F4FF300022A20 /* EmojiView */ = {
@@ -1437,6 +1416,7 @@
 				39EEF68728CBB81600437654 /* BaseCollectionViewCell.swift in Sources */,
 				52136FD4298299B90022D465 /* RepeatCycleView.swift in Sources */,
 				52136FD92983E87F0022D465 /* RepeatCycleCollectionViewCell.swift in Sources */,
+				52B6BD112A9FA2D100022A20 /* AddFeedbackView.swift in Sources */,
 				522714ED297922AA006BADBC /* SetHouseWorkCollectionViewCell.swift in Sources */,
 				52136FE1298A72130022D465 /* WriteHouseWorkViewController.swift in Sources */,
 				5204AAB929507319002FB6CA /* SettingAlarmTableViewCell.swift in Sources */,

--- a/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
+++ b/fairer-iOS/fairer-iOS.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		52B6BD0F2A9F501F00022A20 /* EmojiCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B6BD0E2A9F501F00022A20 /* EmojiCollectionViewCell.swift */; };
 		52B6BD112A9FA2D100022A20 /* AddFeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B6BD102A9FA2D100022A20 /* AddFeedbackView.swift */; };
 		52B6BD132A9FACE000022A20 /* EditFeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B6BD122A9FACE000022A20 /* EditFeedbackView.swift */; };
+		52B6BD152A9FB20C00022A20 /* HurryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B6BD142A9FB20C00022A20 /* HurryView.swift */; };
 		52C09CED29113D3500B46F15 /* HouseMemberCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C09CEC29113D3500B46F15 /* HouseMemberCollectionView.swift */; };
 		52C09CEF29113D3800B46F15 /* HouseMemberCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C09CEE29113D3700B46F15 /* HouseMemberCollectionViewCell.swift */; };
 		52C09CF329115FC300B46F15 /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C09CF229115FC300B46F15 /* SettingViewController.swift */; };
@@ -262,6 +263,7 @@
 		52B6BD0E2A9F501F00022A20 /* EmojiCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCollectionViewCell.swift; sourceTree = "<group>"; };
 		52B6BD102A9FA2D100022A20 /* AddFeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFeedbackView.swift; sourceTree = "<group>"; };
 		52B6BD122A9FACE000022A20 /* EditFeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditFeedbackView.swift; sourceTree = "<group>"; };
+		52B6BD142A9FB20C00022A20 /* HurryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HurryView.swift; sourceTree = "<group>"; };
 		52C09CEC29113D3500B46F15 /* HouseMemberCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HouseMemberCollectionView.swift; sourceTree = "<group>"; };
 		52C09CEE29113D3700B46F15 /* HouseMemberCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HouseMemberCollectionViewCell.swift; sourceTree = "<group>"; };
 		52C09CF229115FC300B46F15 /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
@@ -783,6 +785,7 @@
 				52B6BD0B2A9F4FF300022A20 /* EmojiView */,
 				52B6BD102A9FA2D100022A20 /* AddFeedbackView.swift */,
 				52B6BD122A9FACE000022A20 /* EditFeedbackView.swift */,
+				52B6BD142A9FB20C00022A20 /* HurryView.swift */,
 			);
 			path = FeedbackView;
 			sourceTree = "<group>";
@@ -1527,6 +1530,7 @@
 				917D8B7329A633A200E26B73 /* MembersAPI.swift in Sources */,
 				917D8B5F29A632D000E26B73 /* HouseWorksRouter.swift in Sources */,
 				911455C0297E7FD7002CCDF9 /* WorkState.swift in Sources */,
+				52B6BD152A9FB20C00022A20 /* HurryView.swift in Sources */,
 				917D8B7129A6339700E26B73 /* HouseWorksAPI.swift in Sources */,
 				91CB591C29977B09002A3295 /* PickDateView.swift in Sources */,
 				5A80308C29925146005C7909 /* SettingHomeRuleTableViewCell.swift in Sources */,

--- a/fairer-iOS/fairer-iOS/Global/Literal/ImageLiteral.swift
+++ b/fairer-iOS/fairer-iOS/Global/Literal/ImageLiteral.swift
@@ -96,6 +96,7 @@ enum ImageLiterals {
     static var error: UIImage { .load(name: "error") }
     static var homeIcon: UIImage { .load(name: "home") }
     static var pencil: UIImage { .load(systemName: "pencil") }
+    static var trash: UIImage { .load(systemName: "trash") }
     
     // MARK: - dot
     

--- a/fairer-iOS/fairer-iOS/Global/Literal/ImageLiteral.swift
+++ b/fairer-iOS/fairer-iOS/Global/Literal/ImageLiteral.swift
@@ -97,6 +97,7 @@ enum ImageLiterals {
     static var homeIcon: UIImage { .load(name: "home") }
     static var pencil: UIImage { .load(systemName: "pencil") }
     static var trash: UIImage { .load(systemName: "trash") }
+    static var hurry: UIImage { .load(systemName: "megaphone.fill") }
     
     // MARK: - dot
     

--- a/fairer-iOS/fairer-iOS/Global/Literal/ImageLiteral.swift
+++ b/fairer-iOS/fairer-iOS/Global/Literal/ImageLiteral.swift
@@ -95,6 +95,7 @@ enum ImageLiterals {
     static var houseFill: UIImage { .load(systemName: "house.fill") }
     static var error: UIImage { .load(name: "error") }
     static var homeIcon: UIImage { .load(name: "home") }
+    static var pencil: UIImage { .load(systemName: "pencil") }
     
     // MARK: - dot
     

--- a/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
+++ b/fairer-iOS/fairer-iOS/Global/Literal/TextLiteral.swift
@@ -76,6 +76,13 @@ enum TextLiteral {
     static let homeCalendarViewTodayTitle: String = "오늘"
     static let homeCalendarViewDaysTitle: [String] = ["일","월","화","수","목","금","토"]
     
+    // MARK: - Feedback
+    
+    static let feedbackViewAddFeedbackLabel: String = "텍스트 피드백 작성"
+    static let feedbackViewEditFeedbackLabel: String = "텍스트 피드백 수정"
+    static let feedbackViewDeleteFeedbackLabel: String = "텍스트 피드백 삭제"
+    static let feedbackViewHurryLabel: String = "재촉하기"
+    
     // MARK: - HouseInviteCodeViewController
     
     static let houseInviteCodeViewControllerPrimaryLabel: String = "하우스에 사람을 초대해주세요."

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/AddFeedbackView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/AddFeedbackView.swift
@@ -32,7 +32,7 @@ final class AddFeedbackView: BaseUIView {
         imageView.tintColor = .gray800
         return imageView
     }()
-    private let emojiCollectionView = EmojiCollectionView()
+    let emojiCollectionView = EmojiCollectionView()
     
     // MARK: - life cycle
     

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/AddFeedbackView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/AddFeedbackView.swift
@@ -1,0 +1,89 @@
+//
+//  AddFeedbackView.swift
+//  fairer-iOS
+//
+//  Created by 김유나 on 2023/08/31.
+//
+
+import UIKit
+
+final class AddFeedbackView: BaseUIView {
+    
+    var didTappedAddFeedbackButton: (() -> ())?
+    
+    // MARK: - property
+    
+    private let addFeedbackButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .white
+        button.layer.cornerRadius = 8
+        return button
+    }()
+    private let addFeedbackLabel: UILabel = {
+        let label = UILabel()
+        label.text = "텍스트 피드백 작성"
+        label.font = .body1
+        label.textColor = .gray800
+        return label
+    }()
+    private let addFeedbackImage: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = ImageLiterals.pencil
+        imageView.tintColor = .gray800
+        return imageView
+    }()
+    private let emojiCollectionView = EmojiCollectionView()
+    
+    // MARK: - life cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        render()
+        configUI()
+        setButtonAction()
+    }
+    
+    required init?(coder: NSCoder) { nil }
+    
+    override func render() {
+        self.addSubviews(emojiCollectionView, addFeedbackButton)
+        addFeedbackButton.addSubviews(addFeedbackLabel, addFeedbackImage)
+        
+        emojiCollectionView.snp.makeConstraints {
+            $0.bottom.leading.trailing.equalToSuperview()
+            $0.height.equalTo(52)
+        }
+        
+        addFeedbackButton.snp.makeConstraints {
+            $0.bottom.equalTo(emojiCollectionView.snp.top).offset(-4)
+            $0.height.equalTo(42)
+            $0.leading.trailing.equalToSuperview()
+        }
+        
+        addFeedbackLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(16)
+            $0.centerY.equalToSuperview()
+        }
+        
+        addFeedbackImage.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(16)
+            $0.width.equalTo(20)
+            $0.height.equalTo(24)
+            $0.centerY.equalToSuperview()
+        }
+    }
+    
+    override func configUI() {
+        self.layer.shadowOpacity = 0.24
+        self.layer.shadowRadius = 18
+    }
+    
+    // MARK: - func
+    
+    private func setButtonAction() {
+        let addFeedbackAction = UIAction { [weak self] _ in
+            self?.didTappedAddFeedbackButton?()
+        }
+        addFeedbackButton.addAction(addFeedbackAction, for: .touchUpInside)
+    }
+}

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/AddFeedbackView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/AddFeedbackView.swift
@@ -21,7 +21,7 @@ final class AddFeedbackView: BaseUIView {
     }()
     private let addFeedbackLabel: UILabel = {
         let label = UILabel()
-        label.text = "텍스트 피드백 작성"
+        label.text = TextLiteral.feedbackViewAddFeedbackLabel
         label.font = .body1
         label.textColor = .gray800
         return label

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/AddFeedbackView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/AddFeedbackView.swift
@@ -38,8 +38,6 @@ final class AddFeedbackView: BaseUIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        render()
-        configUI()
         setButtonAction()
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/AddFeedbackView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/AddFeedbackView.swift
@@ -57,7 +57,7 @@ final class AddFeedbackView: BaseUIView {
         addFeedbackButton.snp.makeConstraints {
             $0.bottom.equalTo(emojiCollectionView.snp.top).offset(-4)
             $0.height.equalTo(42)
-            $0.leading.trailing.equalToSuperview()
+            $0.width.equalTo(272)
         }
         
         addFeedbackLabel.snp.makeConstraints {

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/EditFeedbackView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/EditFeedbackView.swift
@@ -88,7 +88,7 @@ final class EditFeedbackView: BaseUIView {
         feedbackBackgroundView.snp.makeConstraints {
             $0.bottom.equalTo(emojiCollectionView.snp.top).offset(-4)
             $0.height.equalTo(84)
-            $0.leading.trailing.equalToSuperview()
+            $0.width.equalTo(272)
         }
         
         editFeedbackButton.snp.makeConstraints {

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/EditFeedbackView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/EditFeedbackView.swift
@@ -1,0 +1,153 @@
+//
+//  EditFeedbackView.swift
+//  fairer-iOS
+//
+//  Created by 김유나 on 2023/08/31.
+//
+
+import UIKit
+
+final class EditFeedbackView: BaseUIView {
+    
+    var didTappedEditFeedbackButton: (() -> ())?
+    var didTappedDeleteFeedbackButton: (() -> ())?
+    
+    // MARK: - property
+    
+    private let feedbackBackgroundView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.layer.cornerRadius = 8
+        return view
+    }()
+    private let editFeedbackButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .clear
+        return button
+    }()
+    private let editFeedbackLabel: UILabel = {
+        let label = UILabel()
+        label.text = "텍스트 피드백 수정"
+        label.font = .body1
+        label.textColor = .gray800
+        return label
+    }()
+    private let editFeedbackImage: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = ImageLiterals.pencil
+        imageView.tintColor = .gray800
+        return imageView
+    }()
+    private let dividerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .gray100
+        return view
+    }()
+    private let deleteFeedbackButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .clear
+        return button
+    }()
+    private let deleteFeedbackLabel: UILabel = {
+        let label = UILabel()
+        label.text = "텍스트 피드백 삭제"
+        label.font = .body1
+        label.textColor = .negative20
+        return label
+    }()
+    private let deleteFeedbackImage: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = ImageLiterals.trash
+        imageView.tintColor = .negative20
+        return imageView
+    }()
+    private let emojiCollectionView = EmojiCollectionView()
+    
+    // MARK: - life cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        render()
+        configUI()
+        setButtonAction()
+    }
+    
+    required init?(coder: NSCoder) { nil }
+    
+    override func render() {
+        self.addSubviews(emojiCollectionView, feedbackBackgroundView)
+        feedbackBackgroundView.addSubviews(editFeedbackButton, dividerView, deleteFeedbackButton)
+        editFeedbackButton.addSubviews(editFeedbackLabel, editFeedbackImage)
+        deleteFeedbackButton.addSubviews(deleteFeedbackLabel, deleteFeedbackImage)
+        
+        emojiCollectionView.snp.makeConstraints {
+            $0.bottom.leading.trailing.equalToSuperview()
+            $0.height.equalTo(52)
+        }
+        
+        feedbackBackgroundView.snp.makeConstraints {
+            $0.bottom.equalTo(emojiCollectionView.snp.top).offset(-4)
+            $0.height.equalTo(84)
+            $0.leading.trailing.equalToSuperview()
+        }
+        
+        editFeedbackButton.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(42)
+        }
+        
+        dividerView.snp.makeConstraints {
+            $0.top.equalTo(editFeedbackButton.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(1)
+        }
+        
+        deleteFeedbackButton.snp.makeConstraints {
+            $0.bottom.leading.trailing.equalToSuperview()
+            $0.height.equalTo(42)
+        }
+        
+        editFeedbackLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(16)
+            $0.centerY.equalToSuperview()
+        }
+        
+        editFeedbackImage.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(16)
+            $0.width.equalTo(20)
+            $0.height.equalTo(24)
+            $0.centerY.equalToSuperview()
+        }
+        
+        deleteFeedbackLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(16)
+            $0.centerY.equalToSuperview()
+        }
+        
+        deleteFeedbackImage.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(16)
+            $0.width.equalTo(20)
+            $0.height.equalTo(24)
+            $0.centerY.equalToSuperview()
+        }
+    }
+    
+    override func configUI() {
+        self.layer.shadowOpacity = 0.24
+        self.layer.shadowRadius = 18
+    }
+    
+    // MARK: - func
+    
+    private func setButtonAction() {
+        let editFeedbackAction = UIAction { [weak self] _ in
+            self?.didTappedEditFeedbackButton?()
+        }
+        editFeedbackButton.addAction(editFeedbackAction, for: .touchUpInside)
+        
+        let deleteFeedbackAction = UIAction { [weak self] _ in
+            self?.didTappedDeleteFeedbackButton?()
+        }
+        deleteFeedbackButton.addAction(deleteFeedbackAction, for: .touchUpInside)
+    }
+}

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/EditFeedbackView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/EditFeedbackView.swift
@@ -27,7 +27,7 @@ final class EditFeedbackView: BaseUIView {
     }()
     private let editFeedbackLabel: UILabel = {
         let label = UILabel()
-        label.text = "텍스트 피드백 수정"
+        label.text = TextLiteral.feedbackViewEditFeedbackLabel
         label.font = .body1
         label.textColor = .gray800
         return label
@@ -50,7 +50,7 @@ final class EditFeedbackView: BaseUIView {
     }()
     private let deleteFeedbackLabel: UILabel = {
         let label = UILabel()
-        label.text = "텍스트 피드백 삭제"
+        label.text = TextLiteral.feedbackViewDeleteFeedbackLabel
         label.font = .body1
         label.textColor = .negative20
         return label

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/EditFeedbackView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/EditFeedbackView.swift
@@ -67,8 +67,6 @@ final class EditFeedbackView: BaseUIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        render()
-        configUI()
         setButtonAction()
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/EditFeedbackView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/EditFeedbackView.swift
@@ -61,7 +61,7 @@ final class EditFeedbackView: BaseUIView {
         imageView.tintColor = .negative20
         return imageView
     }()
-    private let emojiCollectionView = EmojiCollectionView()
+    let emojiCollectionView = EmojiCollectionView()
     
     // MARK: - life cycle
     

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/EmojiView/EmojiCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/EmojiView/EmojiCollectionView.swift
@@ -21,6 +21,7 @@ final class EmojiCollectionView: BaseUIView {
             bottom: collectionVerticalSpacing,
             right: collectionHorizontalSpacing)
     }
+    var selectedEmojiList = [Int:Bool]()
     
     // MARK: - property
 
@@ -39,7 +40,6 @@ final class EmojiCollectionView: BaseUIView {
     lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
         collectionView.backgroundColor = .clear
-        collectionView.delegate = self
         collectionView.dataSource = self
         collectionView.allowsMultipleSelection = true
         collectionView.register(EmojiCollectionViewCell.self, forCellWithReuseIdentifier: EmojiCollectionViewCell.className)
@@ -63,17 +63,11 @@ final class EmojiCollectionView: BaseUIView {
 
 // MARK: - extension
 
-extension EmojiCollectionView: UICollectionViewDelegate {
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-    }
-}
-
 extension EmojiCollectionView: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return ImageLiterals.emojiList.count
+        let emojiNum = ImageLiterals.emojiList.count
+        selectedEmojiList = Dictionary(uniqueKeysWithValues: (0..<emojiNum).map{($0, false)})
+        return emojiNum
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -84,6 +78,16 @@ extension EmojiCollectionView: UICollectionViewDataSource {
         
         cell.emojiImageView.image = ImageLiterals.emojiList[indexPath.item]
         
+        let action = UIAction { [weak self] _ in
+            self?.didTappedEmoji(indexPath.item)
+            cell.isSelected.toggle()
+        }
+        cell.backView.addAction(action, for: .touchUpInside)
+        
         return cell
+    }
+    
+    private func didTappedEmoji(_ index: Int) {
+        selectedEmojiList[index]?.toggle()
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/EmojiView/EmojiCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/EmojiView/EmojiCollectionView.swift
@@ -28,8 +28,6 @@ final class EmojiCollectionView: BaseUIView {
         let view = UIView()
         view.backgroundColor = .white
         view.layer.cornerRadius = 8
-        view.layer.shadowOpacity = 0.24
-        view.layer.shadowRadius = 18
         return view
     }()
     private let collectionViewFlowLayout: UICollectionViewFlowLayout = {

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/EmojiView/EmojiCollectionView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/EmojiView/EmojiCollectionView.swift
@@ -21,7 +21,7 @@ final class EmojiCollectionView: BaseUIView {
             bottom: collectionVerticalSpacing,
             right: collectionHorizontalSpacing)
     }
-    var selectedEmojiList = [Int:Bool]()
+    var selectedEmojiList = [Int : Bool]()
     
     // MARK: - property
 

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/EmojiView/EmojiCollectionViewCell.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/EmojiView/EmojiCollectionViewCell.swift
@@ -19,8 +19,8 @@ final class EmojiCollectionViewCell: BaseCollectionViewCell {
     
     // MARK: - property
     
-    private let backView: UIView = {
-        let view = UIView()
+    let backView: UIButton = {
+        let view = UIButton()
         view.backgroundColor = .clear
         view.layer.cornerRadius = 8
         return view

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/HurryView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/HurryView.swift
@@ -1,0 +1,81 @@
+//
+//  HurryView.swift
+//  fairer-iOS
+//
+//  Created by 김유나 on 2023/08/31.
+//
+
+import UIKit
+
+final class HurryView: BaseUIView {
+    
+    var didTappedHurryButton: (() -> ())?
+    
+    // MARK: - property
+    
+    private let hurryButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .white
+        button.layer.cornerRadius = 8
+        return button
+    }()
+    private let hurryLabel: UILabel = {
+        let label = UILabel()
+        label.text = "재촉하기"
+        label.font = .body1
+        label.textColor = .gray800
+        return label
+    }()
+    private let hurryImage: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = ImageLiterals.hurry
+        imageView.tintColor = .gray800
+        return imageView
+    }()
+    
+    // MARK: - life cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        render()
+        configUI()
+        setButtonAction()
+    }
+    
+    required init?(coder: NSCoder) { nil }
+    
+    override func render() {
+        self.addSubviews(hurryButton)
+        hurryButton.addSubviews(hurryLabel, hurryImage)
+        
+        hurryButton.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        hurryLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(16)
+            $0.centerY.equalToSuperview()
+        }
+        
+        hurryImage.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(16)
+            $0.width.equalTo(18)
+            $0.height.equalTo(22)
+            $0.centerY.equalToSuperview()
+        }
+    }
+    
+    override func configUI() {
+        self.layer.shadowOpacity = 0.24
+        self.layer.shadowRadius = 18
+    }
+    
+    // MARK: - func
+    
+    private func setButtonAction() {
+        let hurryAction = UIAction { [weak self] _ in
+            self?.didTappedHurryButton?()
+        }
+        hurryButton.addAction(hurryAction, for: .touchUpInside)
+    }
+}

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/HurryView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/FeedbackView/HurryView.swift
@@ -21,7 +21,7 @@ final class HurryView: BaseUIView {
     }()
     private let hurryLabel: UILabel = {
         let label = UILabel()
-        label.text = "재촉하기"
+        label.text = TextLiteral.feedbackViewHurryLabel
         label.font = .body1
         label.textColor = .gray800
         return label

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/HomeView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/HomeView.swift
@@ -74,6 +74,7 @@ final class HomeView: BaseUIView {
         return view
     }()
     let emptyHouseWorkImage = UIImageView(image: ImageLiterals.emptyHouseWork)
+    let addFeedbackView = AddFeedbackView()
     
     override func render() {
         self.addSubviews(toolBarView,
@@ -87,7 +88,7 @@ final class HomeView: BaseUIView {
                          homeCalenderView,
                          homeWeekCalendarCollectionView,
                          calendarDailyTableView,
-                         emptyHouseWorkImage)
+                         emptyHouseWorkImage, addFeedbackView)
         
         toolBarView.snp.makeConstraints {
             $0.leading.trailing.bottom.equalTo(self.safeAreaLayoutGuide)
@@ -160,6 +161,13 @@ final class HomeView: BaseUIView {
             $0.bottom.equalTo(toolBarView.snp.top).offset(-10)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(emptyHouseWorkImage.snp.height).multipliedBy(0.65)
+        }
+        
+        addFeedbackView.snp.makeConstraints {
+            $0.top.equalTo(calendarDailyTableView.snp.bottom).offset(-10)
+            $0.leading.equalToSuperview().inset(10)
+            $0.width.equalTo(UIScreen.main.bounds.width * 0.9)
+            $0.height.equalTo(98)
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/HomeView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/HomeView.swift
@@ -90,7 +90,7 @@ final class HomeView: BaseUIView {
                          homeCalenderView,
                          homeWeekCalendarCollectionView,
                          calendarDailyTableView,
-                         emptyHouseWorkImage, editFeedbackView)
+                         emptyHouseWorkImage)
         
         toolBarView.snp.makeConstraints {
             $0.leading.trailing.bottom.equalTo(self.safeAreaLayoutGuide)

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/HomeView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/HomeView.swift
@@ -74,7 +74,7 @@ final class HomeView: BaseUIView {
         return view
     }()
     let emptyHouseWorkImage = UIImageView(image: ImageLiterals.emptyHouseWork)
-    let editFeedbackView = EditFeedbackView()
+    let editFeedbackView = HurryView()
     
     override func render() {
         self.addSubviews(toolBarView,
@@ -166,8 +166,8 @@ final class HomeView: BaseUIView {
         editFeedbackView.snp.makeConstraints {
             $0.top.equalTo(calendarDailyTableView.snp.bottom).offset(-40)
             $0.leading.equalToSuperview().inset(10)
-            $0.width.equalTo(UIScreen.main.bounds.width * 0.9)
-            $0.height.equalTo(140)
+            $0.width.equalTo(UIScreen.main.bounds.width * 0.76)
+            $0.height.equalTo(42)
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/HomeView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/HomeView.swift
@@ -74,7 +74,7 @@ final class HomeView: BaseUIView {
         return view
     }()
     let emptyHouseWorkImage = UIImageView(image: ImageLiterals.emptyHouseWork)
-    let addFeedbackView = AddFeedbackView()
+    let editFeedbackView = EditFeedbackView()
     
     override func render() {
         self.addSubviews(toolBarView,
@@ -88,7 +88,7 @@ final class HomeView: BaseUIView {
                          homeCalenderView,
                          homeWeekCalendarCollectionView,
                          calendarDailyTableView,
-                         emptyHouseWorkImage, addFeedbackView)
+                         emptyHouseWorkImage, editFeedbackView)
         
         toolBarView.snp.makeConstraints {
             $0.leading.trailing.bottom.equalTo(self.safeAreaLayoutGuide)
@@ -163,11 +163,11 @@ final class HomeView: BaseUIView {
             $0.width.equalTo(emptyHouseWorkImage.snp.height).multipliedBy(0.65)
         }
         
-        addFeedbackView.snp.makeConstraints {
-            $0.top.equalTo(calendarDailyTableView.snp.bottom).offset(-10)
+        editFeedbackView.snp.makeConstraints {
+            $0.top.equalTo(calendarDailyTableView.snp.bottom).offset(-40)
             $0.leading.equalToSuperview().inset(10)
             $0.width.equalTo(UIScreen.main.bounds.width * 0.9)
-            $0.height.equalTo(98)
+            $0.height.equalTo(140)
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/View/HomeView.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/View/HomeView.swift
@@ -74,7 +74,9 @@ final class HomeView: BaseUIView {
         return view
     }()
     let emptyHouseWorkImage = UIImageView(image: ImageLiterals.emptyHouseWork)
-    let editFeedbackView = HurryView()
+    let addFeedbackView = AddFeedbackView()
+    let editFeedbackView = EditFeedbackView()
+    let hurryView = HurryView()
     
     override func render() {
         self.addSubviews(toolBarView,
@@ -161,13 +163,6 @@ final class HomeView: BaseUIView {
             $0.bottom.equalTo(toolBarView.snp.top).offset(-10)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(emptyHouseWorkImage.snp.height).multipliedBy(0.65)
-        }
-        
-        editFeedbackView.snp.makeConstraints {
-            $0.top.equalTo(calendarDailyTableView.snp.bottom).offset(-40)
-            $0.leading.equalToSuperview().inset(10)
-            $0.width.equalTo(UIScreen.main.bounds.width * 0.76)
-            $0.height.equalTo(42)
         }
     }
 }

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -254,10 +254,14 @@ final class HomeViewController: BaseViewController {
         }
         
         if homeView.addFeedbackView.isDescendant(of: homeView) {
+            // FIXME: - 선택된 이모지 피드백 post
+            print(homeView.addFeedbackView.emojiCollectionView.selectedEmojiList)
             homeView.addFeedbackView.removeFromSuperview()
         }
         
         if homeView.editFeedbackView.isDescendant(of: homeView) {
+            // FIXME: - 선택된 이모지 피드백 post
+            print(homeView.editFeedbackView.emojiCollectionView.selectedEmojiList)
             homeView.editFeedbackView.removeFromSuperview()
         }
         

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -24,6 +24,8 @@ final class HomeViewController: BaseViewController {
     private var reloadHouseWork = false
     private lazy var leftSwipeGestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(handleSwipes(_:)))
     private lazy var rightSwipeGestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(handleSwipes(_:)))
+    private var addViewGesture: UILongPressGestureRecognizer?
+    private var removeViewGesture: UITapGestureRecognizer?
     private var selectedMemberId: Int?
     private var myId: Int?
     private lazy var divideIndex: Int = 0
@@ -142,7 +144,22 @@ final class HomeViewController: BaseViewController {
 
         homeView.addFeedbackView.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(16)
-            $0.width.equalTo(UIScreen.main.bounds.width * 0.88)
+            $0.width.equalTo(UIScreen.main.bounds.width * 0.9)
+            $0.height.equalTo(98)
+            $0.top.equalToSuperview().inset(viewPosition.y - 104)
+        }
+    }
+    
+    private func addEditFeedbackView(_ row: IndexPath) {
+        let rectOfCellInTableView = self.homeView.calendarDailyTableView.rectForRow(at: IndexPath(row: row[1], section: row[0]))
+        let rectOfCellInSuperview = self.homeView.calendarDailyTableView.convert(rectOfCellInTableView, to: self.view)
+        let viewPosition = CGPoint(x: rectOfCellInSuperview.origin.x, y: rectOfCellInSuperview.origin.y)
+
+        view.addSubview(homeView.editFeedbackView)
+
+        homeView.editFeedbackView.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(16)
+            $0.width.equalTo(UIScreen.main.bounds.width * 0.9)
             $0.height.equalTo(140)
             $0.top.equalToSuperview().inset(viewPosition.y - 146)
         }
@@ -195,13 +212,14 @@ final class HomeViewController: BaseViewController {
     }
     
     private func setupFeedbackViewGesture() {
-        let addViewGesture = UILongPressGestureRecognizer(target: self, action: #selector(addFeedbackViewGesture))
-        let removeViewGesture = UITapGestureRecognizer(target: self, action: #selector(removeFeedbackViewGesture))
+        addViewGesture = UILongPressGestureRecognizer(target: self, action: #selector(addFeedbackViewGesture))
+        removeViewGesture = UITapGestureRecognizer(target: self, action: #selector(removeFeedbackViewGesture))
+
+        homeView.calendarDailyTableView.addGestureRecognizer(addViewGesture!)
+        homeView.addGestureRecognizer(removeViewGesture!)
         
-        if !checkMemberCellIsOwn() {
-            homeView.addGestureRecognizer(removeViewGesture)
-            homeView.calendarDailyTableView.addGestureRecognizer(addViewGesture)
-        }
+        addViewGesture?.isEnabled = false
+        removeViewGesture?.isEnabled = false
     }
     
     @objc
@@ -220,11 +238,13 @@ final class HomeViewController: BaseViewController {
                     addHurryView(row)
                 } else {
                     // FIXME: - 텍스트 피드백 ? addEditFeedback : addAddFeedback
-                    addAddFeedbackView(row)
-//                    addEditFeedbackView(row)
+//                    addAddFeedbackView(row)
+                    addEditFeedbackView(row)
                 }
             }
         }
+        
+        removeViewGesture?.isEnabled = true
     }
     
     @objc
@@ -236,6 +256,12 @@ final class HomeViewController: BaseViewController {
         if homeView.addFeedbackView.isDescendant(of: homeView) {
             homeView.addFeedbackView.removeFromSuperview()
         }
+        
+        if homeView.editFeedbackView.isDescendant(of: homeView) {
+            homeView.editFeedbackView.removeFromSuperview()
+        }
+        
+        removeViewGesture?.isEnabled = false
     }
     
     @objc
@@ -714,6 +740,7 @@ private extension HomeViewController {
             )
             self.getHouseWorksByWeek()
         }
+        addViewGesture?.isEnabled = !checkMemberCellIsOwn()
     }
     
     @objc func handleSwipes(_ sender:UISwipeGestureRecognizer) {

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -111,7 +111,7 @@ final class HomeViewController: BaseViewController {
     override func configUI() {
         super.configUI()
         setupToolBarGesture()
-        setupLongPressGesture()
+        setupFeedbackViewGesture()
     }
     
     override func render() {
@@ -179,9 +179,12 @@ final class HomeViewController: BaseViewController {
         homeView.homeRuleView.addGestureRecognizer(tapRuleGesture)
     }
     
-    private func setupLongPressGesture() {
-        let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(addLongPressGesture))
-        homeView.calendarDailyTableView.addGestureRecognizer(longPressGesture)
+    private func setupFeedbackViewGesture() {
+        let addViewGesture = UILongPressGestureRecognizer(target: self, action: #selector(addFeedbackViewGesture))
+        let removeViewGesture = UITapGestureRecognizer(target: self, action: #selector(removeFeedbackViewGesture))
+        
+        homeView.calendarDailyTableView.addGestureRecognizer(addViewGesture)
+        homeView.addGestureRecognizer(removeViewGesture)
     }
     
     @objc
@@ -192,7 +195,7 @@ final class HomeViewController: BaseViewController {
     }
     
     @objc
-    private func addLongPressGesture(_ sender: UILongPressGestureRecognizer) {
+    private func addFeedbackViewGesture(_ sender: UILongPressGestureRecognizer) {
         if sender.state == .began {
             if let row = homeView.calendarDailyTableView.indexPathForRow(at: sender.location(in: self.homeView.calendarDailyTableView)) {
                 guard let houseWorkCard = self.pickDayWorkInfo?.houseWorks?[row[0]] else { return }
@@ -202,6 +205,13 @@ final class HomeViewController: BaseViewController {
                     // FIXME: - 텍스트 피드백 여부 확인
                 }
             }
+        }
+    }
+    
+    @objc
+    private func removeFeedbackViewGesture(_ sender: UITapGestureRecognizer) {
+        if homeView.hurryView.isDescendant(of: homeView) {
+            homeView.hurryView.removeFromSuperview()
         }
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -129,7 +129,22 @@ final class HomeViewController: BaseViewController {
             $0.leading.equalToSuperview().inset(16)
             $0.width.equalTo(UIScreen.main.bounds.width * 0.76)
             $0.height.equalTo(42)
-            $0.top.equalToSuperview().inset(viewPosition.y - 47)
+            $0.top.equalToSuperview().inset(viewPosition.y - 48)
+        }
+    }
+    
+    private func addAddFeedbackView(_ row: IndexPath) {
+        let rectOfCellInTableView = self.homeView.calendarDailyTableView.rectForRow(at: IndexPath(row: row[1], section: row[0]))
+        let rectOfCellInSuperview = self.homeView.calendarDailyTableView.convert(rectOfCellInTableView, to: self.view)
+        let viewPosition = CGPoint(x: rectOfCellInSuperview.origin.x, y: rectOfCellInSuperview.origin.y)
+
+        view.addSubview(homeView.addFeedbackView)
+
+        homeView.addFeedbackView.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(16)
+            $0.width.equalTo(UIScreen.main.bounds.width * 0.88)
+            $0.height.equalTo(140)
+            $0.top.equalToSuperview().inset(viewPosition.y - 146)
         }
     }
     
@@ -183,8 +198,10 @@ final class HomeViewController: BaseViewController {
         let addViewGesture = UILongPressGestureRecognizer(target: self, action: #selector(addFeedbackViewGesture))
         let removeViewGesture = UITapGestureRecognizer(target: self, action: #selector(removeFeedbackViewGesture))
         
-        homeView.calendarDailyTableView.addGestureRecognizer(addViewGesture)
-        homeView.addGestureRecognizer(removeViewGesture)
+        if !checkMemberCellIsOwn() {
+            homeView.addGestureRecognizer(removeViewGesture)
+            homeView.calendarDailyTableView.addGestureRecognizer(addViewGesture)
+        }
     }
     
     @objc
@@ -202,7 +219,9 @@ final class HomeViewController: BaseViewController {
                 if houseWorkCard.success {
                     addHurryView(row)
                 } else {
-                    // FIXME: - 텍스트 피드백 여부 확인
+                    // FIXME: - 텍스트 피드백 ? addEditFeedback : addAddFeedback
+                    addAddFeedbackView(row)
+//                    addEditFeedbackView(row)
                 }
             }
         }
@@ -212,6 +231,10 @@ final class HomeViewController: BaseViewController {
     private func removeFeedbackViewGesture(_ sender: UITapGestureRecognizer) {
         if homeView.hurryView.isDescendant(of: homeView) {
             homeView.hurryView.removeFromSuperview()
+        }
+        
+        if homeView.addFeedbackView.isDescendant(of: homeView) {
+            homeView.addFeedbackView.removeFromSuperview()
         }
     }
     

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -111,10 +111,26 @@ final class HomeViewController: BaseViewController {
     override func configUI() {
         super.configUI()
         setupToolBarGesture()
+        setupLongPressGesture()
     }
     
     override func render() {
         self.view = homeView
+    }
+    
+    private func addHurryView(_ row: IndexPath) {
+        let rectOfCellInTableView = self.homeView.calendarDailyTableView.rectForRow(at: IndexPath(row: row[1], section: row[0]))
+        let rectOfCellInSuperview = self.homeView.calendarDailyTableView.convert(rectOfCellInTableView, to: self.view)
+        let viewPosition = CGPoint(x: rectOfCellInSuperview.origin.x, y: rectOfCellInSuperview.origin.y)
+
+        view.addSubview(homeView.hurryView)
+
+        homeView.hurryView.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(16)
+            $0.width.equalTo(UIScreen.main.bounds.width * 0.76)
+            $0.height.equalTo(42)
+            $0.top.equalToSuperview().inset(viewPosition.y - 47)
+        }
     }
     
     //MARK: - set up view
@@ -163,11 +179,30 @@ final class HomeViewController: BaseViewController {
         homeView.homeRuleView.addGestureRecognizer(tapRuleGesture)
     }
     
+    private func setupLongPressGesture() {
+        let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(addLongPressGesture))
+        homeView.calendarDailyTableView.addGestureRecognizer(longPressGesture)
+    }
+    
     @objc
     private func addTapGesture() {
         reloadHouseWork = false
         let selectHouseWorkView = SelectHouseWorkViewController()
         self.navigationController?.pushViewController(selectHouseWorkView, animated: true)
+    }
+    
+    @objc
+    private func addLongPressGesture(_ sender: UILongPressGestureRecognizer) {
+        if sender.state == .began {
+            if let row = homeView.calendarDailyTableView.indexPathForRow(at: sender.location(in: self.homeView.calendarDailyTableView)) {
+                guard let houseWorkCard = self.pickDayWorkInfo?.houseWorks?[row[0]] else { return }
+                if houseWorkCard.success {
+                    addHurryView(row)
+                } else {
+                    // FIXME: - 텍스트 피드백 여부 확인
+                }
+            }
+        }
     }
     
     @objc

--- a/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
+++ b/fairer-iOS/fairer-iOS/Screens/Home/Home/ViewController/HomeViewController.swift
@@ -235,11 +235,11 @@ final class HomeViewController: BaseViewController {
             if let row = homeView.calendarDailyTableView.indexPathForRow(at: sender.location(in: self.homeView.calendarDailyTableView)) {
                 guard let houseWorkCard = self.pickDayWorkInfo?.houseWorks?[row[0]] else { return }
                 if houseWorkCard.success {
-                    addHurryView(row)
-                } else {
                     // FIXME: - 텍스트 피드백 ? addEditFeedback : addAddFeedback
-//                    addAddFeedbackView(row)
+                    // addAddFeedbackView(row)
                     addEditFeedbackView(row)
+                } else {
+                    addHurryView(row)
                 }
             }
         }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #269 

## 👩‍💻 Contents & Screenshot
<!-- 작업 내용과 이미지를 첨부해주세요. -->

### 피드백 수정(삭제) 뷰

https://github.com/fairer-iOS/fairer-iOS/assets/81340603/ac492a3e-8a5e-4599-af7e-dde63bdf82a0

### 재촉하기 뷰

https://github.com/fairer-iOS/fairer-iOS/assets/81340603/b00d0005-c7be-44dc-9764-a0e853488bf0

- 전에 만들어 뒀던 EmojiCollectionView를 피드백 추가/수정 뷰에 올렸습니당
- 피드백을 추가하고 싶은 tableview cell을 long press 할 경우 homeview에 뷰가 추가되고, view 외 다른 영역을 터치했을 때 view가 제거됩니당


## 📌 Review Point
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- 코드에 대해 조금 설명하자면
  1. Home viewDidLoad 시점에 집안일 카드 tableView와 homeView에 tap gesture 만들고 일단은 비활성화(setupFeedbackViewGesture)
  2. 유저 본인을 제외한 다른 멤버의 프로필을 터치했을 때 집안일 카드 tableView에 걸어둔 long press gesture를 활성화
  3. 끝난 집안일인 경우 HurryView를 아직 끝내지 않은 집안일의 경우 피드백 여부에 따라 AddFeedbackView 혹은 EditFeedbackView을 HomeView에 추가
  4. 이때 HomeView에 만들어둔 tap gesture를 활성화 > 이 gesture는 FeedbackView 외 다른 곳을 선택했을 때 FeedbackView를 제거해주기 위한 gesture
  5. FeedbackView가 HomeView에서 제거된 이후에 다른 컴포넌트를 정상적으로 동작시키기 위해 homeView의 gesture를 비활성화
 
- 원래 EmojiCollectionView Cell의 선택을 collectionview에 있는 didSelect 로 구현하려고 했으나,, AddFeedbackView와 EditFeedbackView를 없애기 위해 HomeView에 넣어두었던 tap gesture recognizer가 이상하게 CollectionView의 didSelect보다 우선순위가 높더라구요,, 
  분명 CollectionView 아래에 있는 UIView에 넣어둔 tap gesture 였는데 ,, CollectionView를 뚫고 UIView gesture가 동작해서 이모지 선택이 안되고 FeedbackView가 사라지기만 합니다
  그래서 생각한 방법이 CollectionView Cell의 배경 뷰를 view 대신 button으로 선언하고 그 button에 action을 추가했습니다! 진짜 이해가 안되는 게 button은 잘 동작해요 ㅋㅋㅋ 원인은 아직까지 모르겠어요 select가 collectionview의 주기능이 아니라서 그런가,,,


## 🔓 Next Step
<!-- 다음으로 할 일을 적어주세요. -->
- 피드백 캡슐 UI 만들기

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[TableView의 특정 셀의 좌표 얻기]
https://dev-geeyong.tistory.com/65
